### PR TITLE
feat(config): unify region/domain/internal settings

### DIFF
--- a/.codebuddy/rules/changelog.mdc
+++ b/.codebuddy/rules/changelog.mdc
@@ -1,0 +1,50 @@
+---
+description: 
+alwaysApply: true
+enabled: true
+updatedAt: 2026-03-04T08:12:51.546Z
+provider: 
+---
+
+# Changelog Update Rule
+
+When making functional code changes (not purely documentation or CI changes), the `[Unreleased]` section in both `CHANGELOG.md` and `CHANGELOG-zh.md` **MUST** be updated in the same session.
+
+## Trigger Conditions
+
+Update CHANGELOG when any of these occur:
+
+- Adding, removing, or modifying features
+- Changing CLI flags, commands, or configuration structure
+- Fixing bugs
+- Deprecating or removing functionality
+- Changing internal behavior that affects users
+
+## Do NOT Trigger For
+
+- Pure documentation edits (typo fixes, rewording)
+- CI/CD pipeline changes
+- Test-only changes
+- Code formatting / linting fixes
+
+## What to Update
+
+Add entries under `[Unreleased]` / `[未发布]` using the appropriate category:
+
+| English | Chinese | When |
+|---------|---------|------|
+| Added | 新增 | New features, flags, commands, config options |
+| Changed | 变更 | Behavior changes, refactors affecting users |
+| Fixed | 修复 | Bug fixes |
+| Deprecated | 废弃 | Features marked for removal |
+| Removed | 移除 | Features removed |
+| Security | 安全 | Security-related changes |
+
+## Rules
+
+1. **Both languages**: Always update `CHANGELOG.md` and `CHANGELOG-zh.md` together
+2. **Concise entries**: Each entry should be a single clear sentence describing the user-visible change
+3. **No version numbers**: Only add to `[Unreleased]` — version assignment happens during release
+4. **Follow existing style**: Match the tone and format of existing CHANGELOG entries
+5. **Based on final diff, not development iterations**: CHANGELOG entries must reflect the final delivered state compared to the last released version, NOT intermediate fixes made during development. If a bug was introduced and fixed within the same unreleased cycle, do NOT add a "Fixed" entry — the user never experienced the bug. Always run `git diff` against the base branch to determine what actually changed from the user's perspective.
+6. **No process artifacts**: Do not record code review iterations, refactoring steps, or intermediate corrections as separate CHANGELOG entries. The CHANGELOG is a user-facing document, not a development log.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  fmt:
+    name: Format Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Check gofmt
+        run: |
+          DIFF=$(gofmt -d .)
+          if [ -n "$DIFF" ]; then
+            echo "The following files are not formatted:"
+            echo "$DIFF"
+            exit 1
+          fi
+
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: go test -v -race -coverprofile=coverage.out ./...
+
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage.out
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,9 @@
+version: "2"
+
+linters:
+  settings:
+    errcheck:
+      exclude-functions:
+        - fmt.Fprint
+        - fmt.Fprintf
+        - fmt.Fprintln

--- a/CHANGELOG-zh.md
+++ b/CHANGELOG-zh.md
@@ -7,6 +7,20 @@
 ### 新增
 - 为 `exec`、`file` 和 `instance login` 命令添加 `--user` 参数，支持指定数据面操作的用户身份（默认值: "user"）
 - 在 config.toml 中添加 `sandbox.default_user` 配置项，支持全局设置默认用户
+- 新增顶层统一配置字段 `region`、`domain`、`internal`，替代后端特定的重复配置
+- 新增全局 CLI 参数 `--region`、`--domain`、`--internal`
+- 新增环境变量 `AGS_REGION`、`AGS_DOMAIN`、`AGS_INTERNAL`
+- 新增独立配置参考文档（`docs/ags-config.md`）
+
+### 变更
+- 统一 region/domain/internal 配置：所有数据面和控制面操作现在从顶层配置字段读取，不再分别从 `[e2b]` 或 `[cloud]` 段获取
+- 控制面客户端（`CloudControlPlane`、`E2BControlPlane`）现使用统一配置的 region 和 domain
+- 在配置解析阶段将 `internal` 标志归一化到 `domain` 中：当 `internal=true` 时，domain 自动加上 `internal.` 前缀（如 `internal.tencentags.com`），确保 E2B 和 Cloud 后端的 endpoint 拼接一致
+
+### 废弃
+- 配置字段 `e2b.region`、`e2b.domain`、`cloud.region`、`cloud.internal` 已废弃，请使用顶层 `region`、`domain`、`internal`
+- CLI 参数 `--e2b-region`、`--e2b-domain`、`--cloud-region`、`--cloud-internal` 已废弃，请使用 `--region`、`--domain`、`--internal`
+- 环境变量 `AGS_E2B_REGION`、`AGS_E2B_DOMAIN`、`AGS_CLOUD_REGION`、`AGS_CLOUD_INTERNAL` 已废弃，请使用 `AGS_REGION`、`AGS_DOMAIN`、`AGS_INTERNAL`
 
 ## [0.1.2] - 2026-02-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Add `--user` flag to `exec`, `file`, and `instance login` commands to specify the user identity for data plane operations (default: "user")
 - Add `sandbox.default_user` configuration option in config.toml for setting the default user globally
+- Add unified top-level `region`, `domain`, and `internal` configuration fields to replace backend-specific duplicates
+- Add `--region`, `--domain`, and `--internal` global CLI flags
+- Add `AGS_REGION`, `AGS_DOMAIN`, and `AGS_INTERNAL` environment variables
+- Add dedicated configuration reference documentation (`docs/ags-config.md`)
+
+### Changed
+- Unify region/domain/internal configuration: all data plane and control plane operations now read from top-level config fields instead of backend-specific `[e2b]` or `[cloud]` sections
+- Control plane clients (`CloudControlPlane`, `E2BControlPlane`) now use unified config for region and domain
+- Normalize `internal` flag into `domain` at config resolution time: when `internal=true`, the domain is automatically prefixed with `internal.` (e.g., `internal.tencentags.com`), ensuring consistent endpoint construction for both E2B and Cloud backends
+
+### Deprecated
+- Config fields `e2b.region`, `e2b.domain`, `cloud.region`, `cloud.internal` are deprecated in favor of top-level `region`, `domain`, `internal`
+- CLI flags `--e2b-region`, `--e2b-domain`, `--cloud-region`, `--cloud-internal` are deprecated in favor of `--region`, `--domain`, `--internal`
+- Environment variables `AGS_E2B_REGION`, `AGS_E2B_DOMAIN`, `AGS_CLOUD_REGION`, `AGS_CLOUD_INTERNAL` are deprecated in favor of `AGS_REGION`, `AGS_DOMAIN`, `AGS_INTERNAL`
 
 ## [0.1.2] - 2026-02-11
 

--- a/cmd/browser.go
+++ b/cmd/browser.go
@@ -129,15 +129,15 @@ func browserVNCCommand(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to acquire access token: %w", err)
 	}
 
-	// Get cloud config for region info
-	cloudCfg := config.GetCloudConfig()
+	// Get unified config for region info
+	cfg := config.Get()
 
 	// Build VNC URL
 	// Format: https://{port}-{sandbox_id}.{region}.{domain}/novnc/vnc_lite.html?&path=websockify?access_token={token}
-	vncURL := buildVNCURL(instance.ID, cloudCfg.Region, cloudCfg.DataPlaneDomain(), accessToken, browserPort)
+	vncURL := buildVNCURL(instance.ID, cfg.Region, cfg.DataPlaneDomain(), accessToken, browserPort)
 
 	// Build CDP URL for programmatic access
-	cdpURL := buildCDPURL(instance.ID, cloudCfg.Region, cloudCfg.DataPlaneDomain(), accessToken, browserPort)
+	cdpURL := buildCDPURL(instance.ID, cfg.Region, cfg.DataPlaneDomain(), accessToken, browserPort)
 
 	totalDuration := time.Since(start)
 	var timing *output.Timing

--- a/cmd/file.go
+++ b/cmd/file.go
@@ -260,7 +260,7 @@ func fileUploadCommand(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to open local file: %w", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	sandbox, cleanup, createDuration, err := getSandboxForFile(ctx)
 	if err != nil {
@@ -336,7 +336,7 @@ func fileDownloadCommand(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create local file: %w", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	n, err := io.Copy(file, reader)
 	if err != nil {

--- a/cmd/instance.go
+++ b/cmd/instance.go
@@ -624,13 +624,8 @@ Examples:
 		}
 
 		// Determine data plane domain
-		cloudCfg := config.GetCloudConfig()
-		var domain string
-		if cloudCfg.Internal {
-			domain = cloudCfg.DataPlaneDomain()
-		} else {
-			domain = fmt.Sprintf("%s.tencentags.com", cloudCfg.Region)
-		}
+		cfg := config.Get()
+		domain := cfg.DataPlaneRegionDomain()
 
 		// Create webshell manager with access token (no AKSK needed)
 		webshellMgr := webshell.NewManagerWithToken(accessToken, domain)
@@ -760,8 +755,8 @@ Examples:
 // buildWebshellURL builds webshell access URL
 // Format: https://{port}-{instance_id}.{region}.{domain}/?access_token={token}
 func buildWebshellURL(instanceID, accessToken string) string {
-	cloudCfg := config.GetCloudConfig()
-	host := fmt.Sprintf("8080-%s.%s.%s", instanceID, cloudCfg.Region, cloudCfg.DataPlaneDomain())
+	cfg := config.Get()
+	host := fmt.Sprintf("8080-%s.%s.%s", instanceID, cfg.Region, cfg.DataPlaneDomain())
 	return fmt.Sprintf("https://%s/?access_token=%s", host, accessToken)
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,15 +14,19 @@ var (
 	backend     string
 	outputFmt   string
 	showVersion bool
+	// Unified flags
+	region   string
+	domain   string
+	internal bool
 	// E2B flags
 	e2bAPIKey string
-	e2bDomain string
-	e2bRegion string
+	e2bDomain string // Deprecated: use --domain
+	e2bRegion string // Deprecated: use --region
 	// Cloud flags
 	cloudSecretID  string
 	cloudSecretKey string
-	cloudRegion    string
-	cloudInternal  bool
+	cloudRegion    string // Deprecated: use --region
+	cloudInternal  bool   // Deprecated: use --internal
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -113,16 +117,27 @@ func init() {
 	// Version flag (local to root command only)
 	rootCmd.Flags().BoolVarP(&showVersion, "version", "v", false, "Print version information")
 
+	// Unified flags (recommended)
+	rootCmd.PersistentFlags().StringVar(&region, "region", "", "Region for API access (default: ap-guangzhou)")
+	rootCmd.PersistentFlags().StringVar(&domain, "domain", "", "Base domain (default: tencentags.com)")
+	rootCmd.PersistentFlags().BoolVar(&internal, "internal", false, "Use internal endpoints (for Tencent Cloud internal network)")
+
 	// E2B flags
 	rootCmd.PersistentFlags().StringVar(&e2bAPIKey, "e2b-api-key", "", "E2B API key")
-	rootCmd.PersistentFlags().StringVar(&e2bDomain, "e2b-domain", "", "E2B domain (default: tencentags.com)")
-	rootCmd.PersistentFlags().StringVar(&e2bRegion, "e2b-region", "", "E2B region (default: ap-guangzhou)")
+	rootCmd.PersistentFlags().StringVar(&e2bDomain, "e2b-domain", "", "E2B domain (deprecated: use --domain)")
+	rootCmd.PersistentFlags().StringVar(&e2bRegion, "e2b-region", "", "E2B region (deprecated: use --region)")
 
 	// Cloud flags
 	rootCmd.PersistentFlags().StringVar(&cloudSecretID, "cloud-secret-id", "", "Tencent Cloud SecretID")
 	rootCmd.PersistentFlags().StringVar(&cloudSecretKey, "cloud-secret-key", "", "Tencent Cloud SecretKey")
-	rootCmd.PersistentFlags().StringVar(&cloudRegion, "cloud-region", "", "Tencent Cloud region (default: ap-guangzhou)")
-	rootCmd.PersistentFlags().BoolVar(&cloudInternal, "cloud-internal", false, "Use internal endpoints (for Tencent Cloud internal network)")
+	rootCmd.PersistentFlags().StringVar(&cloudRegion, "cloud-region", "", "Tencent Cloud region (deprecated: use --region)")
+	rootCmd.PersistentFlags().BoolVar(&cloudInternal, "cloud-internal", false, "Use internal endpoints (deprecated: use --internal)")
+
+	// Mark deprecated flags
+	_ = rootCmd.PersistentFlags().MarkDeprecated("e2b-domain", "use --domain instead")
+	_ = rootCmd.PersistentFlags().MarkDeprecated("e2b-region", "use --region instead")
+	_ = rootCmd.PersistentFlags().MarkDeprecated("cloud-region", "use --region instead")
+	_ = rootCmd.PersistentFlags().MarkDeprecated("cloud-internal", "use --internal instead")
 }
 
 func initConfig() {
@@ -144,28 +159,39 @@ func initConfig() {
 		config.SetOutput(outputFmt)
 	}
 
-	// E2B overrides
+	// Credential overrides (not subject to priority ordering)
 	if e2bAPIKey != "" {
 		config.SetE2BAPIKey(e2bAPIKey)
 	}
-	if e2bDomain != "" {
-		config.SetE2BDomain(e2bDomain)
-	}
-	if e2bRegion != "" {
-		config.SetE2BRegion(e2bRegion)
-	}
-
-	// Cloud overrides
 	if cloudSecretID != "" {
 		config.SetCloudSecretID(cloudSecretID)
 	}
 	if cloudSecretKey != "" {
 		config.SetCloudSecretKey(cloudSecretKey)
 	}
+
+	// Legacy overrides (lower priority, applied first so unified flags can override)
+	if e2bDomain != "" {
+		config.SetE2BDomain(e2bDomain)
+	}
+	if e2bRegion != "" {
+		config.SetE2BRegion(e2bRegion)
+	}
 	if cloudRegion != "" {
 		config.SetCloudRegion(cloudRegion)
 	}
-	if cloudInternal {
+	if rootCmd.PersistentFlags().Changed("cloud-internal") {
 		config.SetCloudInternal(cloudInternal)
+	}
+
+	// Unified overrides (highest priority, applied last)
+	if region != "" {
+		config.SetRegion(region)
+	}
+	if domain != "" {
+		config.SetDomain(domain)
+	}
+	if rootCmd.PersistentFlags().Changed("internal") {
+		config.SetInternal(internal)
 	}
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -62,27 +62,27 @@ func getCredential() common.CredentialIface {
 
 // getCreateOptions returns the common create options for sandbox
 func getCreateOptions() []code.CreateOption {
-	cloudCfg := config.GetCloudConfig()
+	cfg := config.Get()
 	opts := []code.CreateOption{
 		code.WithCredential(getCredential()),
-		code.WithRegion(cloudCfg.Region),
+		code.WithRegion(cfg.Region),
 		code.WithSandboxTimeout(300 * time.Second),
 	}
-	if cloudCfg.Internal {
-		opts = append(opts, code.WithDataPlaneDomain(cloudCfg.DataPlaneDomain()))
+	if cfg.Internal {
+		opts = append(opts, code.WithDataPlaneDomain(cfg.DataPlaneDomain()))
 	}
 	return opts
 }
 
 // getConnectOptions returns the common connect options for sandbox
 func getConnectOptions() []code.ConnectOption {
-	cloudCfg := config.GetCloudConfig()
+	cfg := config.Get()
 	opts := []code.ConnectOption{
 		code.WithCredential(getCredential()),
-		code.WithRegion(cloudCfg.Region),
+		code.WithRegion(cfg.Region),
 	}
-	if cloudCfg.Internal {
-		opts = append(opts, code.WithDataPlaneDomain(cloudCfg.DataPlaneDomain()))
+	if cfg.Internal {
+		opts = append(opts, code.WithDataPlaneDomain(cfg.DataPlaneDomain()))
 	}
 	return opts
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -74,19 +74,6 @@ func getCreateOptions() []code.CreateOption {
 	return opts
 }
 
-// getConnectOptions returns the common connect options for sandbox
-func getConnectOptions() []code.ConnectOption {
-	cfg := config.Get()
-	opts := []code.ConnectOption{
-		code.WithCredential(getCredential()),
-		code.WithRegion(cfg.Region),
-	}
-	if cfg.Internal {
-		opts = append(opts, code.WithDataPlaneDomain(cfg.DataPlaneDomain()))
-	}
-	return opts
-}
-
 func runCommand(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
@@ -842,14 +829,14 @@ func openEditor(language string) (string, error) {
 		return "", fmt.Errorf("failed to create temp file: %w", err)
 	}
 	tmpPath := tmpFile.Name()
-	defer os.Remove(tmpPath)
+	defer func() { _ = os.Remove(tmpPath) }()
 
 	template := getEditorTemplate(language)
 	if _, err := tmpFile.WriteString(template); err != nil {
-		tmpFile.Close()
+		_ = tmpFile.Close()
 		return "", fmt.Errorf("failed to write template: %w", err)
 	}
-	tmpFile.Close()
+	_ = tmpFile.Close()
 
 	cmd := exec.Command(editor, tmpPath)
 	cmd.Stdin = os.Stdin

--- a/cmd/sandbox_helper.go
+++ b/cmd/sandbox_helper.go
@@ -49,15 +49,10 @@ func resolveUser(flagValue string) string {
 //   - *code.Sandbox: A sandbox instance with data plane clients initialized
 //   - error: Any error encountered during initialization
 func ConnectWithToken(ctx context.Context, instanceID string, accessToken string) (*code.Sandbox, error) {
-	cloudCfg := config.GetCloudConfig()
+	cfg := config.Get()
 
 	// Determine the data plane domain
-	var domain string
-	if cloudCfg.Internal {
-		domain = cloudCfg.DataPlaneDomain()
-	} else {
-		domain = fmt.Sprintf("%s.tencentags.com", cloudCfg.Region)
-	}
+	domain := cfg.DataPlaneRegionDomain()
 
 	// Create connection config
 	connConfig := &connection.Config{

--- a/cmd/sandbox_helper.go
+++ b/cmd/sandbox_helper.go
@@ -128,11 +128,8 @@ func GetCachedTokenOrAcquire(ctx context.Context, instanceID string) (string, er
 		return "", err
 	}
 
-	// Cache the newly acquired token
-	if err := tokenCache.Set(instanceID, accessToken); err != nil {
-		// Log warning but don't fail
-		// The operation can still succeed without caching
-	}
+	// Cache the newly acquired token (best-effort, ignore errors)
+	_ = tokenCache.Set(instanceID, accessToken)
 
 	return accessToken, nil
 }

--- a/config.example.toml
+++ b/config.example.toml
@@ -7,22 +7,35 @@ backend = "e2b"
 # Default output format: "text" or "json"
 output = "text"
 
+# Region for API access (default: ap-guangzhou)
+# region = "ap-guangzhou"
+
+# Base domain for AGS services (default: tencentags.com)
+# domain = "tencentags.com"
+
+# Use internal endpoints for Tencent Cloud internal network (default: false)
+# When true, "internal." is automatically prepended to the domain, e.g.:
+#   - E2B control plane: api.{region}.internal.tencentags.com
+#   - Cloud control plane: ags.internal.tencentcloudapi.com
+#   - Data plane: {port}-{id}.{region}.internal.tencentags.com
+# internal = false
+
 # E2B API Configuration
 [e2b]
 api_key = ""
-domain = "tencentags.com"
-region = "ap-guangzhou"
+# Deprecated: use top-level "domain" instead
+# domain = "tencentags.com"
+# Deprecated: use top-level "region" instead
+# region = "ap-guangzhou"
 
 # Cloud API Configuration (Tencent Cloud)
 [cloud]
 secret_id = ""
 secret_key = ""
-region = "ap-guangzhou"
-# Use internal endpoints for Tencent Cloud internal network (default: false)
-# When true, uses:
-#   - Control plane: ags.internal.tencentcloudapi.com
-#   - Data plane: internal.tencentags.com
-internal = false
+# Deprecated: use top-level "region" instead
+# region = "ap-guangzhou"
+# Deprecated: use top-level "internal" instead
+# internal = false
 
 # Sandbox Configuration
 [sandbox]

--- a/docs/ags-config-zh.md
+++ b/docs/ags-config-zh.md
@@ -1,0 +1,169 @@
+# ags-config
+
+AGS CLI 配置参考
+
+## 配置文件
+
+默认配置文件位于 `~/.ags/config.toml`。可通过 `--config` 选项指定其他路径：
+
+```bash
+ags --config /path/to/config.toml
+```
+
+### 完整示例
+
+```toml
+# 后端类型："e2b" 或 "cloud"
+backend = "e2b"
+
+# 默认输出格式："text" 或 "json"
+output = "text"
+
+# API 访问地域（默认：ap-guangzhou）
+# region = "ap-guangzhou"
+
+# AGS 服务基础域名（默认：tencentags.com）
+# domain = "tencentags.com"
+
+# 使用内网端点（默认：false）
+# 设为 true 时，domain 会自动加上 "internal." 前缀
+# internal = false
+
+# E2B API 配置
+[e2b]
+api_key = "your-e2b-api-key"
+
+# 腾讯云 API 配置
+[cloud]
+secret_id = "your-secret-id"
+secret_key = "your-secret-key"
+
+# 沙箱配置
+[sandbox]
+default_user = "user"
+```
+
+## 配置字段
+
+### 顶层字段
+
+| 字段 | 类型 | 默认值 | 描述 |
+|------|------|--------|------|
+| `backend` | string | `e2b` | API 后端：`e2b` 或 `cloud` |
+| `output` | string | `text` | 输出格式：`text` 或 `json` |
+| `region` | string | `ap-guangzhou` | API 访问地域 |
+| `domain` | string | `tencentags.com` | AGS 服务基础域名 |
+| `internal` | bool | `false` | 使用内网端点（腾讯云内网） |
+
+### `[e2b]` 段
+
+| 字段 | 类型 | 描述 |
+|------|------|------|
+| `api_key` | string | E2B API 密钥（`backend = "e2b"` 时必需） |
+
+### `[cloud]` 段
+
+| 字段 | 类型 | 描述 |
+|------|------|------|
+| `secret_id` | string | 腾讯云 SecretID（`backend = "cloud"` 时必需） |
+| `secret_key` | string | 腾讯云 SecretKey（`backend = "cloud"` 时必需） |
+
+### `[sandbox]` 段
+
+| 字段 | 类型 | 默认值 | 描述 |
+|------|------|--------|------|
+| `default_user` | string | `user` | 数据面操作的默认用户 |
+
+## 环境变量
+
+所有配置字段均可通过 `AGS_` 前缀的环境变量设置：
+
+| 环境变量 | 配置字段 | 描述 |
+|----------|----------|------|
+| `AGS_BACKEND` | `backend` | API 后端 |
+| `AGS_OUTPUT` | `output` | 输出格式 |
+| `AGS_REGION` | `region` | 地域 |
+| `AGS_DOMAIN` | `domain` | 基础域名 |
+| `AGS_INTERNAL` | `internal` | 使用内网端点 |
+| `AGS_E2B_API_KEY` | `e2b.api_key` | E2B API 密钥 |
+| `AGS_CLOUD_SECRET_ID` | `cloud.secret_id` | 腾讯云 SecretID |
+| `AGS_CLOUD_SECRET_KEY` | `cloud.secret_key` | 腾讯云 SecretKey |
+| `AGS_SANDBOX_DEFAULT_USER` | `sandbox.default_user` | 默认沙箱用户 |
+
+## 优先级
+
+配置值按以下顺序解析（优先级从高到低）：
+
+1. **命令行选项**（如 `--region`、`--domain`）
+2. **环境变量**（如 `AGS_REGION`）
+3. **配置文件**（`~/.ags/config.toml`）
+4. **默认值**
+
+## 内网模式（internal）
+
+`internal` 字段控制 AGS CLI 是否使用腾讯云内网端点。设为 `true` 时，在配置解析阶段 `domain` 会自动加上 `internal.` 前缀。这种归一化确保所有后端的 endpoint 拼接一致。
+
+### 工作原理
+
+配置解析时，如果 `internal = true` 且 `domain` 尚未以 `internal.` 开头，则自动转换：
+
+```
+domain = "tencentags.com"  →  domain = "internal.tencentags.com"
+```
+
+归一化后，所有 endpoint 函数直接使用转换后的 `domain`：
+
+| 端点 | 外网（`internal=false`） | 内网（`internal=true`） |
+|------|--------------------------|------------------------|
+| E2B 控制面 | `api.{region}.tencentags.com` | `api.{region}.internal.tencentags.com` |
+| Cloud 控制面 | `ags.tencentcloudapi.com` | `ags.internal.tencentcloudapi.com` |
+| 数据面 | `{region}.tencentags.com` | `{region}.internal.tencentags.com` |
+
+### 等效配置
+
+以下两种配置效果完全相同：
+
+**使用 `internal` 标志（推荐）：**
+```toml
+domain = "tencentags.com"
+internal = true
+```
+
+**直接设置 domain：**
+```toml
+domain = "internal.tencentags.com"
+internal = false
+```
+
+> **注意**：如果两者同时设置（`domain = "internal.tencentags.com"` 且 `internal = true`），CLI 会检测到已有的 `internal.` 前缀，不会重复添加，不会报错。
+>
+> **注意**：`domain` 的值应为不含 `internal.` 前缀的基础域名。如需使用内网端点，请设置 `internal = true`，而非手动在 domain 前加 `internal.` 前缀。
+
+## 已废弃字段
+
+以下 `[e2b]` 和 `[cloud]` 段中的字段已废弃，请使用顶层字段替代：
+
+| 废弃字段 | 替代字段 | 环境变量迁移 |
+|----------|----------|-------------|
+| `e2b.domain` | `domain` | `AGS_E2B_DOMAIN` → `AGS_DOMAIN` |
+| `e2b.region` | `region` | `AGS_E2B_REGION` → `AGS_REGION` |
+| `cloud.region` | `region` | `AGS_CLOUD_REGION` → `AGS_REGION` |
+| `cloud.internal` | `internal` | `AGS_CLOUD_INTERNAL` → `AGS_INTERNAL` |
+
+使用废弃字段时会输出警告到 stderr：
+
+```
+Warning: config field "e2b.region" is deprecated, please use top-level "region" instead.
+```
+
+旧字段的解析优先级：
+
+1. 顶层字段（如已设置）
+2. 当前后端对应的旧字段（基于 `backend` 值）
+3. 其他后端的旧字段（静默兜底，不输出废弃警告）
+4. 默认值
+
+## 另请参阅
+
+- [ags](ags-zh.md) - 主命令
+- [config.example.toml](../config.example.toml) - 配置文件示例

--- a/docs/ags-config.md
+++ b/docs/ags-config.md
@@ -1,0 +1,169 @@
+# ags-config
+
+Configuration reference for AGS CLI
+
+## Configuration File
+
+The default configuration file is located at `~/.ags/config.toml`. You can specify a different path with the `--config` flag.
+
+```bash
+ags --config /path/to/config.toml
+```
+
+### Full Example
+
+```toml
+# Backend type: "e2b" or "cloud"
+backend = "e2b"
+
+# Default output format: "text" or "json"
+output = "text"
+
+# Region for API access (default: ap-guangzhou)
+# region = "ap-guangzhou"
+
+# Base domain for AGS services (default: tencentags.com)
+# domain = "tencentags.com"
+
+# Use internal endpoints for Tencent Cloud internal network (default: false)
+# When true, "internal." is automatically prepended to the domain.
+# internal = false
+
+# E2B API Configuration
+[e2b]
+api_key = "your-e2b-api-key"
+
+# Cloud API Configuration (Tencent Cloud)
+[cloud]
+secret_id = "your-secret-id"
+secret_key = "your-secret-key"
+
+# Sandbox Configuration
+[sandbox]
+default_user = "user"
+```
+
+## Configuration Fields
+
+### Top-Level Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `backend` | string | `e2b` | API backend: `e2b` or `cloud` |
+| `output` | string | `text` | Output format: `text` or `json` |
+| `region` | string | `ap-guangzhou` | Region for API access |
+| `domain` | string | `tencentags.com` | Base domain for AGS services |
+| `internal` | bool | `false` | Use internal endpoints (Tencent Cloud internal network) |
+
+### `[e2b]` Section
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `api_key` | string | E2B API key (required when `backend = "e2b"`) |
+
+### `[cloud]` Section
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `secret_id` | string | Tencent Cloud SecretID (required when `backend = "cloud"`) |
+| `secret_key` | string | Tencent Cloud SecretKey (required when `backend = "cloud"`) |
+
+### `[sandbox]` Section
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `default_user` | string | `user` | Default user for data plane operations |
+
+## Environment Variables
+
+All configuration fields can be set via environment variables with the `AGS_` prefix:
+
+| Environment Variable | Config Field | Description |
+|---------------------|--------------|-------------|
+| `AGS_BACKEND` | `backend` | API backend |
+| `AGS_OUTPUT` | `output` | Output format |
+| `AGS_REGION` | `region` | Region |
+| `AGS_DOMAIN` | `domain` | Base domain |
+| `AGS_INTERNAL` | `internal` | Use internal endpoints |
+| `AGS_E2B_API_KEY` | `e2b.api_key` | E2B API key |
+| `AGS_CLOUD_SECRET_ID` | `cloud.secret_id` | Tencent Cloud SecretID |
+| `AGS_CLOUD_SECRET_KEY` | `cloud.secret_key` | Tencent Cloud SecretKey |
+| `AGS_SANDBOX_DEFAULT_USER` | `sandbox.default_user` | Default sandbox user |
+
+## Priority
+
+Configuration values are resolved in the following order (highest priority first):
+
+1. **Command-line flags** (e.g., `--region`, `--domain`)
+2. **Environment variables** (e.g., `AGS_REGION`)
+3. **Configuration file** (`~/.ags/config.toml`)
+4. **Default values**
+
+## Internal Network (internal)
+
+The `internal` field controls whether AGS CLI uses Tencent Cloud internal network endpoints. When set to `true`, the `domain` field is automatically prefixed with `internal.` during configuration resolution. This normalization ensures consistent endpoint construction across all backends.
+
+### How It Works
+
+At config resolution time, if `internal = true` and `domain` does not already start with `internal.`, the domain is automatically transformed:
+
+```
+domain = "tencentags.com"  →  domain = "internal.tencentags.com"
+```
+
+After normalization, all endpoint functions use the resolved `domain` directly:
+
+| Endpoint | External (`internal=false`) | Internal (`internal=true`) |
+|----------|---------------------------|---------------------------|
+| E2B Control Plane | `api.{region}.tencentags.com` | `api.{region}.internal.tencentags.com` |
+| Cloud Control Plane | `ags.tencentcloudapi.com` | `ags.internal.tencentcloudapi.com` |
+| Data Plane | `{region}.tencentags.com` | `{region}.internal.tencentags.com` |
+
+### Equivalent Configurations
+
+The following two configurations produce identical behavior:
+
+**Using `internal` flag (recommended):**
+```toml
+domain = "tencentags.com"
+internal = true
+```
+
+**Using domain directly:**
+```toml
+domain = "internal.tencentags.com"
+internal = false
+```
+
+> **Note**: If both are set (`domain = "internal.tencentags.com"` and `internal = true`), the CLI detects the existing `internal.` prefix and avoids double-prepending. No error will occur.
+>
+> **Note**: The `domain` value should be the base domain without the `internal.` prefix. If you need internal endpoints, use `internal = true` instead of manually prepending `internal.` to the domain.
+
+## Deprecated Fields
+
+The following fields under `[e2b]` and `[cloud]` sections are deprecated. Use the top-level fields instead:
+
+| Deprecated Field | Replacement | Environment Variable |
+|-----------------|-------------|---------------------|
+| `e2b.domain` | `domain` | `AGS_E2B_DOMAIN` → `AGS_DOMAIN` |
+| `e2b.region` | `region` | `AGS_E2B_REGION` → `AGS_REGION` |
+| `cloud.region` | `region` | `AGS_CLOUD_REGION` → `AGS_REGION` |
+| `cloud.internal` | `internal` | `AGS_CLOUD_INTERNAL` → `AGS_INTERNAL` |
+
+When deprecated fields are used, a warning is printed to stderr:
+
+```
+Warning: config field "e2b.region" is deprecated, please use top-level "region" instead.
+```
+
+Legacy fields are still resolved with the following priority:
+
+1. Top-level field (if set)
+2. Backend-specific legacy field (based on current `backend`)
+3. Other backend's legacy field (as silent fallback, no deprecation warning)
+4. Default value
+
+## See Also
+
+- [ags](ags.md) - Main command
+- [config.example.toml](../config.example.toml) - Example configuration file

--- a/docs/ags-zh.md
+++ b/docs/ags-zh.md
@@ -35,49 +35,42 @@ AGS CLI 提供了一种便捷的方式来管理沙箱工具、实例，并在隔
 | `--backend` | string | `e2b` | API 后端：`e2b` 或 `cloud` |
 | `--config` | string | `~/.ags/config.toml` | 配置文件路径 |
 | `-o, --output` | string | `text` | 输出格式：`text` 或 `json` |
+| `--region` | string | `ap-guangzhou` | API 访问地域 |
+| `--domain` | string | `tencentags.com` | 基础域名 |
+| `--internal` | bool | `false` | 使用内网端点（腾讯云内网） |
 | `--e2b-api-key` | string | - | E2B API 密钥 |
-| `--e2b-domain` | string | - | E2B 域名 |
-| `--e2b-region` | string | - | E2B 地域 |
 | `--cloud-secret-id` | string | - | 腾讯云 SecretID |
 | `--cloud-secret-key` | string | - | 腾讯云 SecretKey |
-| `--cloud-region` | string | - | 腾讯云地域 |
-| `--cloud-internal` | bool | `false` | 使用内网端点 |
+
+### 已废弃选项
+
+| 选项 | 替代 |
+|------|------|
+| `--e2b-domain` | `--domain` |
+| `--e2b-region` | `--region` |
+| `--cloud-region` | `--region` |
+| `--cloud-internal` | `--internal` |
 
 ## 配置
-
-### 配置文件
 
 创建 `~/.ags/config.toml`：
 
 ```toml
 backend = "e2b"
 output = "text"
+region = "ap-guangzhou"          # 统一地域，适用于所有后端
+domain = "tencentags.com"        # 统一基础域名（可选）
+internal = false                 # 设为 true 时自动在 domain 前加 "internal." 前缀
 
 [e2b]
 api_key = "your-e2b-api-key"
-domain = "tencentags.com"
-region = "ap-guangzhou"
 
 [cloud]
 secret_id = "your-secret-id"
 secret_key = "your-secret-key"
-region = "ap-guangzhou"
-internal = false
 ```
 
-### 环境变量
-
-```bash
-# E2B 后端
-export AGS_E2B_API_KEY="your-api-key"
-export AGS_E2B_DOMAIN="tencentags.com"
-export AGS_E2B_REGION="ap-guangzhou"
-
-# 云端后端
-export AGS_CLOUD_SECRET_ID="your-secret-id"
-export AGS_CLOUD_SECRET_KEY="your-secret-key"
-export AGS_CLOUD_REGION="ap-guangzhou"
-```
+完整配置参考（包括环境变量、内网模式、优先级规则、废弃字段迁移等），请参阅 [ags-config](ags-config-zh.md)。
 
 ## 示例
 
@@ -100,6 +93,7 @@ ags --backend cloud tool list
 
 ## 另请参阅
 
+- [ags-config](ags-config-zh.md) - 配置参考
 - [ags-tool](ags-tool-zh.md) - 工具管理
 - [ags-instance](ags-instance-zh.md) - 实例管理
 - [ags-run](ags-run-zh.md) - 代码执行

--- a/docs/ags.md
+++ b/docs/ags.md
@@ -35,49 +35,42 @@ When invoked without arguments, AGS enters interactive REPL mode with auto-compl
 | `--backend` | string | `e2b` | API backend: `e2b` or `cloud` |
 | `--config` | string | `~/.ags/config.toml` | Config file path |
 | `-o, --output` | string | `text` | Output format: `text` or `json` |
+| `--region` | string | `ap-guangzhou` | Region for API access |
+| `--domain` | string | `tencentags.com` | Base domain |
+| `--internal` | bool | `false` | Use internal endpoints (for Tencent Cloud internal network) |
 | `--e2b-api-key` | string | - | E2B API key |
-| `--e2b-domain` | string | - | E2B domain |
-| `--e2b-region` | string | - | E2B region |
 | `--cloud-secret-id` | string | - | Tencent Cloud SecretID |
 | `--cloud-secret-key` | string | - | Tencent Cloud SecretKey |
-| `--cloud-region` | string | - | Tencent Cloud region |
-| `--cloud-internal` | bool | `false` | Use internal endpoints |
+
+### Deprecated Flags
+
+| Flag | Replacement |
+|------|-------------|
+| `--e2b-domain` | `--domain` |
+| `--e2b-region` | `--region` |
+| `--cloud-region` | `--region` |
+| `--cloud-internal` | `--internal` |
 
 ## Configuration
-
-### Configuration File
 
 Create `~/.ags/config.toml`:
 
 ```toml
 backend = "e2b"
 output = "text"
+region = "ap-guangzhou"          # Unified region for all backends
+domain = "tencentags.com"        # Unified base domain (optional)
+internal = false                 # When true, "internal." is prepended to domain automatically
 
 [e2b]
 api_key = "your-e2b-api-key"
-domain = "tencentags.com"
-region = "ap-guangzhou"
 
 [cloud]
 secret_id = "your-secret-id"
 secret_key = "your-secret-key"
-region = "ap-guangzhou"
-internal = false
 ```
 
-### Environment Variables
-
-```bash
-# E2B Backend
-export AGS_E2B_API_KEY="your-api-key"
-export AGS_E2B_DOMAIN="tencentags.com"
-export AGS_E2B_REGION="ap-guangzhou"
-
-# Cloud Backend
-export AGS_CLOUD_SECRET_ID="your-secret-id"
-export AGS_CLOUD_SECRET_KEY="your-secret-key"
-export AGS_CLOUD_REGION="ap-guangzhou"
-```
+For full configuration reference including environment variables, internal network setup, priority rules, and deprecated field migration, see [ags-config](ags-config.md).
 
 ## Examples
 
@@ -100,6 +93,7 @@ ags --backend cloud tool list
 
 ## See Also
 
+- [ags-config](ags-config.md) - Configuration reference
 - [ags-tool](ags-tool.md) - Tool management
 - [ags-instance](ags-instance.md) - Instance management
 - [ags-run](ags-run.md) - Code execution

--- a/internal/client/cloud.go
+++ b/internal/client/cloud.go
@@ -19,22 +19,23 @@ type CloudControlPlane struct {
 
 // NewCloudControlPlane creates a new Cloud control plane client
 func NewCloudControlPlane() (*CloudControlPlane, error) {
-	cfg := config.GetCloudConfig()
+	cfg := config.Get()
+	cloudCfg := config.GetCloudConfig()
 
 	// Create tool client (tencentcloud-sdk-go)
-	toolClient, err := NewCloudToolClient(&cfg)
+	toolClient, err := NewCloudToolClient(cfg, &cloudCfg)
 	if err != nil {
 		return nil, err
 	}
 
 	// Create instance client (tencentcloud-sdk-go)
-	instanceClient, err := NewCloudInstanceClient(&cfg)
+	instanceClient, err := NewCloudInstanceClient(cfg, &cloudCfg)
 	if err != nil {
 		return nil, err
 	}
 
 	// Create API key client (tencentcloud-sdk-go)
-	apikeyClient, err := NewCloudAPIKeyClient(&cfg)
+	apikeyClient, err := NewCloudAPIKeyClient(cfg, &cloudCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/client/cloud_apikey.go
+++ b/internal/client/cloud_apikey.go
@@ -16,8 +16,8 @@ type CloudAPIKeyClient struct {
 }
 
 // NewCloudAPIKeyClient creates a new Cloud API Key client
-func NewCloudAPIKeyClient(cfg *config.CloudConfig) (*CloudAPIKeyClient, error) {
-	credential := common.NewCredential(cfg.SecretID, cfg.SecretKey)
+func NewCloudAPIKeyClient(cfg *config.Config, cloudCfg *config.CloudConfig) (*CloudAPIKeyClient, error) {
+	credential := common.NewCredential(cloudCfg.SecretID, cloudCfg.SecretKey)
 
 	cpf := profile.NewClientProfile()
 	cpf.HttpProfile.Endpoint = cfg.ControlPlaneEndpoint()

--- a/internal/client/cloud_instance.go
+++ b/internal/client/cloud_instance.go
@@ -16,14 +16,13 @@ import (
 // Data plane operations are handled by ags-go-sdk via the cmd layer.
 type CloudInstanceClient struct {
 	client          *ags.Client
-	cfg             *config.CloudConfig
 	region          string
 	dataPlaneDomain string
 }
 
 // NewCloudInstanceClient creates a new Cloud Instance client
-func NewCloudInstanceClient(cfg *config.CloudConfig) (*CloudInstanceClient, error) {
-	credential := common.NewCredential(cfg.SecretID, cfg.SecretKey)
+func NewCloudInstanceClient(cfg *config.Config, cloudCfg *config.CloudConfig) (*CloudInstanceClient, error) {
+	credential := common.NewCredential(cloudCfg.SecretID, cloudCfg.SecretKey)
 	cpf := profile.NewClientProfile()
 	cpf.HttpProfile.Endpoint = cfg.ControlPlaneEndpoint()
 
@@ -34,7 +33,6 @@ func NewCloudInstanceClient(cfg *config.CloudConfig) (*CloudInstanceClient, erro
 
 	return &CloudInstanceClient{
 		client:          client,
-		cfg:             cfg,
 		region:          cfg.Region,
 		dataPlaneDomain: cfg.DataPlaneDomain(),
 	}, nil

--- a/internal/client/cloud_tool.go
+++ b/internal/client/cloud_tool.go
@@ -17,8 +17,8 @@ type CloudToolClient struct {
 }
 
 // NewCloudToolClient creates a new Cloud Tool client
-func NewCloudToolClient(cfg *config.CloudConfig) (*CloudToolClient, error) {
-	credential := common.NewCredential(cfg.SecretID, cfg.SecretKey)
+func NewCloudToolClient(cfg *config.Config, cloudCfg *config.CloudConfig) (*CloudToolClient, error) {
+	credential := common.NewCredential(cloudCfg.SecretID, cloudCfg.SecretKey)
 
 	cpf := profile.NewClientProfile()
 	cpf.HttpProfile.Endpoint = cfg.ControlPlaneEndpoint()

--- a/internal/client/e2b.go
+++ b/internal/client/e2b.go
@@ -24,11 +24,12 @@ type E2BControlPlane struct {
 
 // NewE2BControlPlane creates a new E2B control plane client
 func NewE2BControlPlane() (*E2BControlPlane, error) {
-	cfg := config.GetE2BConfig()
+	e2bCfg := config.GetE2BConfig()
+	cfg := config.Get()
 	httpClient := &http.Client{Timeout: 60 * time.Second}
 	return &E2BControlPlane{
 		httpClient: httpClient,
-		apiKey:     cfg.APIKey,
+		apiKey:     e2bCfg.APIKey,
 		domain:     cfg.Domain,
 		region:     cfg.Region,
 	}, nil

--- a/internal/client/e2b.go
+++ b/internal/client/e2b.go
@@ -116,7 +116,7 @@ func (c *E2BControlPlane) CreateInstance(ctx context.Context, opts *CreateInstan
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(resp.Body)
@@ -150,7 +150,7 @@ func (c *E2BControlPlane) ListInstances(ctx context.Context, opts *ListInstances
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -194,7 +194,7 @@ func (c *E2BControlPlane) GetInstance(ctx context.Context, id string) (*Instance
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -232,7 +232,7 @@ func (c *E2BControlPlane) DeleteInstance(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 		body, _ := io.ReadAll(resp.Body)

--- a/internal/client/types.go
+++ b/internal/client/types.go
@@ -255,11 +255,3 @@ func derefInt(i *int64) int {
 	}
 	return int(*i)
 }
-
-// getString safely gets a string value from a map
-func getString(m map[string]any, key string) string {
-	if v, ok := m[key].(string); ok {
-		return v
-	}
-	return ""
-}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,23 +4,29 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/viper"
 )
 
 // Config represents the CLI configuration
 type Config struct {
-	Backend string        `mapstructure:"backend"`
-	Output  string        `mapstructure:"output"`
-	E2B     E2BConfig     `mapstructure:"e2b"`
-	Cloud   CloudConfig   `mapstructure:"cloud"`
-	Sandbox SandboxConfig `mapstructure:"sandbox"`
+	Backend  string        `mapstructure:"backend"`
+	Output   string        `mapstructure:"output"`
+	Region   string        `mapstructure:"region"`   // Unified region for both control plane and data plane
+	Domain   string        `mapstructure:"domain"`   // Unified base domain (normalized: includes "internal." prefix when internal mode is enabled)
+	Internal bool          `mapstructure:"internal"` // Use internal endpoints for both control plane and data plane
+	E2B      E2BConfig     `mapstructure:"e2b"`
+	Cloud    CloudConfig   `mapstructure:"cloud"`
+	Sandbox  SandboxConfig `mapstructure:"sandbox"`
 }
 
 // E2BConfig represents E2B API configuration
 type E2BConfig struct {
 	APIKey string `mapstructure:"api_key"`
+	// Deprecated: Use top-level "domain" instead. Will be removed in a future version.
 	Domain string `mapstructure:"domain"`
+	// Deprecated: Use top-level "region" instead. Will be removed in a future version.
 	Region string `mapstructure:"region"`
 }
 
@@ -28,8 +34,10 @@ type E2BConfig struct {
 type CloudConfig struct {
 	SecretID  string `mapstructure:"secret_id"`
 	SecretKey string `mapstructure:"secret_key"`
-	Region    string `mapstructure:"region"`
-	Internal  bool   `mapstructure:"internal"` // Use internal endpoints for both control plane and data plane
+	// Deprecated: Use top-level "region" instead. Will be removed in a future version.
+	Region string `mapstructure:"region"`
+	// Deprecated: Use top-level "internal" instead. Will be removed in a future version.
+	Internal bool `mapstructure:"internal"`
 }
 
 // SandboxConfig represents sandbox-level configuration
@@ -37,20 +45,40 @@ type SandboxConfig struct {
 	DefaultUser string `mapstructure:"default_user"`
 }
 
-// ControlPlaneEndpoint returns the control plane API endpoint
-func (c *CloudConfig) ControlPlaneEndpoint() string {
+const (
+	defaultRegion = "ap-guangzhou"
+	defaultDomain = "tencentags.com"
+)
+
+// ControlPlaneEndpoint returns the control plane API endpoint for cloud backend.
+// Note: Cloud control plane uses "tencentcloudapi.com" domain system, which is separate from
+// the data plane "tencentags.com" domain. Therefore this endpoint is hardcoded and does not
+// use c.Domain (which only applies to data plane).
+func (c *Config) ControlPlaneEndpoint() string {
 	if c.Internal {
 		return "ags.internal.tencentcloudapi.com"
 	}
 	return "ags.tencentcloudapi.com"
 }
 
-// DataPlaneDomain returns the data plane domain
-func (c *CloudConfig) DataPlaneDomain() string {
-	if c.Internal {
-		return "internal.tencentags.com"
-	}
-	return "tencentags.com"
+// DataPlaneDomain returns the base data plane domain.
+// After normalization in resolveDeprecatedFields, Domain already includes "internal." prefix
+// when internal mode is enabled (e.g., "internal.tencentags.com").
+func (c *Config) DataPlaneDomain() string {
+	return c.Domain
+}
+
+// DataPlaneRegionDomain returns the region-qualified data plane domain
+// (e.g., "ap-guangzhou.tencentags.com" or "ap-guangzhou.internal.tencentags.com").
+// This is used for constructing sandbox connection URLs.
+func (c *Config) DataPlaneRegionDomain() string {
+	return fmt.Sprintf("%s.%s", c.Region, c.Domain)
+}
+
+// E2BControlPlaneEndpoint returns the E2B control plane API endpoint
+// (e.g., "https://api.ap-guangzhou.tencentags.com" or "https://api.ap-guangzhou.internal.tencentags.com").
+func (c *Config) E2BControlPlaneEndpoint() string {
+	return fmt.Sprintf("https://api.%s.%s", c.Region, c.Domain)
 }
 
 var (
@@ -67,12 +95,17 @@ func SetConfigFile(path string) {
 func Init() error {
 	viper.SetConfigType("toml")
 
-	// Set default values
+	// Set default values - top-level unified fields
 	viper.SetDefault("backend", "e2b")
 	viper.SetDefault("output", "text")
-	viper.SetDefault("e2b.domain", "tencentags.com")
-	viper.SetDefault("e2b.region", "ap-guangzhou")
-	viper.SetDefault("cloud.region", "ap-guangzhou")
+	viper.SetDefault("region", "")
+	viper.SetDefault("domain", "")
+	viper.SetDefault("internal", false)
+
+	// Legacy defaults for backward compatibility
+	viper.SetDefault("e2b.domain", "")
+	viper.SetDefault("e2b.region", "")
+	viper.SetDefault("cloud.region", "")
 	viper.SetDefault("cloud.internal", false)
 
 	// Config file path
@@ -92,9 +125,14 @@ func Init() error {
 	viper.SetEnvPrefix("AGS")
 	viper.AutomaticEnv()
 
-	// Bind specific environment variables
+	// Bind specific environment variables - top-level unified fields
 	_ = viper.BindEnv("backend", "AGS_BACKEND")
 	_ = viper.BindEnv("output", "AGS_OUTPUT")
+	_ = viper.BindEnv("region", "AGS_REGION")
+	_ = viper.BindEnv("domain", "AGS_DOMAIN")
+	_ = viper.BindEnv("internal", "AGS_INTERNAL")
+
+	// Legacy environment variable bindings (for backward compatibility)
 	_ = viper.BindEnv("e2b.api_key", "AGS_E2B_API_KEY")
 	_ = viper.BindEnv("e2b.domain", "AGS_E2B_DOMAIN")
 	_ = viper.BindEnv("e2b.region", "AGS_E2B_REGION")
@@ -116,23 +154,85 @@ func Init() error {
 		return fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 
+	// Resolve unified fields from legacy fields with deprecation warnings
+	resolveDeprecatedFields(cfg)
+
 	return nil
+}
+
+// resolveDeprecatedFields merges deprecated [e2b]/[cloud] fields into top-level unified fields.
+// Priority: top-level > legacy (based on current backend) > default
+func resolveDeprecatedFields(c *Config) {
+	// Resolve Region: top-level > cloud.region / e2b.region (based on backend) > default
+	if c.Region == "" {
+		switch c.Backend {
+		case "cloud":
+			if c.Cloud.Region != "" {
+				c.Region = c.Cloud.Region
+				printDeprecationWarning("cloud.region", "region")
+			}
+		case "e2b":
+			if c.E2B.Region != "" {
+				c.Region = c.E2B.Region
+				printDeprecationWarning("e2b.region", "region")
+			}
+		}
+		// Also check the other backend's region as fallback (silent, no deprecation warning
+		// since the field belongs to a different backend than the one currently in use)
+		if c.Region == "" {
+			if c.Cloud.Region != "" {
+				c.Region = c.Cloud.Region
+			} else if c.E2B.Region != "" {
+				c.Region = c.E2B.Region
+			}
+		}
+		if c.Region == "" {
+			c.Region = defaultRegion
+		}
+	}
+
+	// Resolve Domain: top-level > e2b.domain > default
+	if c.Domain == "" {
+		if c.E2B.Domain != "" {
+			c.Domain = c.E2B.Domain
+			printDeprecationWarning("e2b.domain", "domain")
+		} else {
+			c.Domain = defaultDomain
+		}
+	}
+
+	// Resolve Internal: top-level > cloud.internal
+	// Use viper.IsSet to distinguish "user explicitly set internal=false" from "default false".
+	// Without this check, cloud.internal=true would incorrectly override an explicit internal=false.
+	if !viper.IsSet("internal") && c.Cloud.Internal {
+		c.Internal = true
+		printDeprecationWarning("cloud.internal", "internal")
+	}
+
+	// Normalize: merge Internal flag into Domain.
+	// This ensures all endpoint functions can simply use c.Domain without branching on c.Internal.
+	// The "internal" segment sits between region and base domain: {prefix}.{region}.internal.{domain}
+	// By prepending "internal." to Domain here, all downstream fmt.Sprintf("%s.%s", region, domain)
+	// calls automatically produce the correct result.
+	if c.Internal && !strings.HasPrefix(c.Domain, "internal.") {
+		c.Domain = "internal." + c.Domain
+	}
+}
+
+// printDeprecationWarning prints a deprecation warning for a legacy config field
+func printDeprecationWarning(oldField, newField string) {
+	fmt.Fprintf(os.Stderr, "Warning: config field \"%s\" is deprecated, please use top-level \"%s\" instead.\n", oldField, newField)
 }
 
 // Get returns the current configuration
 func Get() *Config {
 	if cfg == nil {
 		cfg = &Config{
-			Backend: "e2b",
-			Output:  "text",
-			E2B: E2BConfig{
-				Domain: "tencentags.com",
-				Region: "ap-guangzhou",
-			},
-			Cloud: CloudConfig{
-				Region:   "ap-guangzhou",
-				Internal: false,
-			},
+			Backend:  "e2b",
+			Output:   "text",
+			Region:   defaultRegion,
+			Domain:   defaultDomain,
+			Internal: false,
 		}
 	}
 	return cfg
@@ -158,6 +258,48 @@ func SetOutput(output string) {
 	Get().Output = output
 }
 
+// GetRegion returns the unified region
+func GetRegion() string {
+	return Get().Region
+}
+
+// SetRegion sets the unified region (for command line override)
+func SetRegion(region string) {
+	Get().Region = region
+}
+
+// GetDomain returns the unified domain
+func GetDomain() string {
+	return Get().Domain
+}
+
+// SetDomain sets the unified domain (for command line override)
+func SetDomain(domain string) {
+	c := Get()
+	c.Domain = domain
+	// Re-normalize: if internal is enabled, ensure domain has the prefix
+	if c.Internal && !strings.HasPrefix(c.Domain, "internal.") {
+		c.Domain = "internal." + c.Domain
+	}
+}
+
+// GetInternal returns whether to use internal endpoints
+func GetInternal() bool {
+	return Get().Internal
+}
+
+// SetInternal sets whether to use internal endpoints (for command line override)
+func SetInternal(internal bool) {
+	c := Get()
+	c.Internal = internal
+	// Normalize domain based on new internal flag
+	if internal && !strings.HasPrefix(c.Domain, "internal.") {
+		c.Domain = "internal." + c.Domain
+	} else if !internal && strings.HasPrefix(c.Domain, "internal.") {
+		c.Domain = strings.TrimPrefix(c.Domain, "internal.")
+	}
+}
+
 // GetE2BConfig returns E2B configuration
 func GetE2BConfig() E2BConfig {
 	return Get().E2B
@@ -169,13 +311,28 @@ func SetE2BAPIKey(key string) {
 }
 
 // SetE2BDomain sets E2B domain (for command line override)
+// Deprecated: Use SetDomain instead.
+// Note: This function is only called from the legacy --e2b-domain flag path in initConfig.
+// The condition below checks whether the top-level domain is still at its default value;
+// if so, it syncs to the unified field. Even if it incorrectly syncs (e.g., user explicitly
+// set domain to the default), the unified --domain flag is always applied after legacy flags,
+// so it will correct any over-write.
 func SetE2BDomain(domain string) {
 	Get().E2B.Domain = domain
+	// Also update top-level domain if not explicitly set
+	if Get().Domain == defaultDomain || Get().Domain == "internal."+defaultDomain {
+		SetDomain(domain)
+	}
 }
 
 // SetE2BRegion sets E2B region (for command line override)
+// Deprecated: Use SetRegion instead.
 func SetE2BRegion(region string) {
 	Get().E2B.Region = region
+	// Also update top-level region if not explicitly set
+	if Get().Region == defaultRegion {
+		Get().Region = region
+	}
 }
 
 // GetCloudConfig returns Cloud API configuration
@@ -194,13 +351,21 @@ func SetCloudSecretKey(key string) {
 }
 
 // SetCloudRegion sets Cloud API region (for command line override)
+// Deprecated: Use SetRegion instead.
 func SetCloudRegion(region string) {
 	Get().Cloud.Region = region
+	// Also update top-level region if not explicitly set
+	if Get().Region == defaultRegion {
+		Get().Region = region
+	}
 }
 
 // SetCloudInternal sets whether to use internal endpoints (for command line override)
+// Deprecated: Use SetInternal instead.
 func SetCloudInternal(internal bool) {
 	Get().Cloud.Internal = internal
+	// Always sync to top-level internal
+	SetInternal(internal)
 }
 
 // GetSandboxUser returns the default sandbox user

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -395,7 +395,7 @@ func Validate() error {
 		}
 	case "cloud":
 		if c.Cloud.SecretID == "" || c.Cloud.SecretKey == "" {
-			return fmt.Errorf("Cloud API credentials are required (set AGS_CLOUD_SECRET_ID/AGS_CLOUD_SECRET_KEY or cloud.secret_id/cloud.secret_key in config)")
+			return fmt.Errorf("cloud API credentials are required (set AGS_CLOUD_SECRET_ID/AGS_CLOUD_SECRET_KEY or cloud.secret_id/cloud.secret_key in config)")
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,519 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// resetGlobals resets package-level state for test isolation.
+func resetGlobals() {
+	cfg = nil
+	cfgFile = ""
+	viper.Reset()
+}
+
+// TestResolveDeprecatedFields_RegionPriority tests region resolution priority:
+// top-level > backend-specific legacy > cross-backend fallback > default
+func TestResolveDeprecatedFields_RegionPriority(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         Config
+		expectedRegion string
+	}{
+		{
+			name:           "default region when nothing set",
+			config:         Config{Backend: "e2b"},
+			expectedRegion: defaultRegion,
+		},
+		{
+			name: "top-level region takes priority over legacy",
+			config: Config{
+				Backend: "cloud",
+				Region:  "ap-shanghai",
+				Cloud:   CloudConfig{Region: "ap-beijing"},
+			},
+			expectedRegion: "ap-shanghai",
+		},
+		{
+			name: "cloud backend uses cloud.region as legacy",
+			config: Config{
+				Backend: "cloud",
+				Cloud:   CloudConfig{Region: "ap-beijing"},
+			},
+			expectedRegion: "ap-beijing",
+		},
+		{
+			name: "e2b backend uses e2b.region as legacy",
+			config: Config{
+				Backend: "e2b",
+				E2B:     E2BConfig{Region: "ap-tokyo"},
+			},
+			expectedRegion: "ap-tokyo",
+		},
+		{
+			name: "cross-backend fallback: e2b backend falls back to cloud.region",
+			config: Config{
+				Backend: "e2b",
+				Cloud:   CloudConfig{Region: "ap-beijing"},
+			},
+			expectedRegion: "ap-beijing",
+		},
+		{
+			name: "cross-backend fallback: cloud backend falls back to e2b.region",
+			config: Config{
+				Backend: "cloud",
+				E2B:     E2BConfig{Region: "ap-tokyo"},
+			},
+			expectedRegion: "ap-tokyo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetGlobals()
+			c := tt.config
+			resolveDeprecatedFields(&c)
+			if c.Region != tt.expectedRegion {
+				t.Errorf("expected region %q, got %q", tt.expectedRegion, c.Region)
+			}
+		})
+	}
+}
+
+// TestResolveDeprecatedFields_DomainPriority tests domain resolution priority:
+// top-level > e2b.domain > default
+func TestResolveDeprecatedFields_DomainPriority(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         Config
+		expectedDomain string
+	}{
+		{
+			name:           "default domain when nothing set",
+			config:         Config{Backend: "e2b"},
+			expectedDomain: defaultDomain,
+		},
+		{
+			name: "top-level domain takes priority over e2b.domain",
+			config: Config{
+				Backend: "e2b",
+				Domain:  "custom.com",
+				E2B:     E2BConfig{Domain: "legacy.com"},
+			},
+			expectedDomain: "custom.com",
+		},
+		{
+			name: "e2b.domain used as legacy fallback",
+			config: Config{
+				Backend: "e2b",
+				E2B:     E2BConfig{Domain: "legacy.com"},
+			},
+			expectedDomain: "legacy.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetGlobals()
+			c := tt.config
+			resolveDeprecatedFields(&c)
+			if c.Domain != tt.expectedDomain {
+				t.Errorf("expected domain %q, got %q", tt.expectedDomain, c.Domain)
+			}
+		})
+	}
+}
+
+// TestResolveDeprecatedFields_InternalResolution tests internal flag resolution,
+// including the viper.IsSet distinction between explicit false and default false.
+func TestResolveDeprecatedFields_InternalResolution(t *testing.T) {
+	tests := []struct {
+		name             string
+		config           Config
+		viperSetInternal bool // whether to call viper.Set("internal", ...)
+		viperInternalVal bool // value to set if viperSetInternal is true
+		expectedInternal bool
+		expectedDomain   string
+	}{
+		{
+			name:             "cloud.internal=true promotes to top-level when internal not set",
+			config:           Config{Backend: "cloud", Cloud: CloudConfig{Internal: true}},
+			expectedInternal: true,
+			expectedDomain:   "internal." + defaultDomain,
+		},
+		{
+			name:             "cloud.internal=false does not change default",
+			config:           Config{Backend: "cloud", Cloud: CloudConfig{Internal: false}},
+			expectedInternal: false,
+			expectedDomain:   defaultDomain,
+		},
+		{
+			name:             "explicit internal=false in viper blocks cloud.internal=true override",
+			config:           Config{Backend: "cloud", Cloud: CloudConfig{Internal: true}},
+			viperSetInternal: true,
+			viperInternalVal: false,
+			expectedInternal: false,
+			expectedDomain:   defaultDomain,
+		},
+		{
+			name:             "explicit internal=true in viper with cloud.internal=false",
+			config:           Config{Backend: "cloud", Internal: true, Cloud: CloudConfig{Internal: false}},
+			viperSetInternal: true,
+			viperInternalVal: true,
+			expectedInternal: true,
+			expectedDomain:   "internal." + defaultDomain,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetGlobals()
+			if tt.viperSetInternal {
+				viper.Set("internal", tt.viperInternalVal)
+			}
+			c := tt.config
+			resolveDeprecatedFields(&c)
+			if c.Internal != tt.expectedInternal {
+				t.Errorf("expected internal=%v, got %v", tt.expectedInternal, c.Internal)
+			}
+			if c.Domain != tt.expectedDomain {
+				t.Errorf("expected domain %q, got %q", tt.expectedDomain, c.Domain)
+			}
+		})
+	}
+}
+
+// TestResolveDeprecatedFields_InternalDomainNormalization tests domain normalization
+// when internal=true, including the "internal." prefix handling.
+func TestResolveDeprecatedFields_InternalDomainNormalization(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         Config
+		expectedDomain string
+	}{
+		{
+			name: "internal=true adds internal. prefix to default domain",
+			config: Config{
+				Backend:  "e2b",
+				Internal: true,
+			},
+			expectedDomain: "internal." + defaultDomain,
+		},
+		{
+			name: "internal=true adds internal. prefix to custom domain",
+			config: Config{
+				Backend:  "e2b",
+				Domain:   "custom.com",
+				Internal: true,
+			},
+			expectedDomain: "internal.custom.com",
+		},
+		{
+			name: "internal=true does not double-prepend if domain already has prefix",
+			config: Config{
+				Backend:  "e2b",
+				Domain:   "internal.custom.com",
+				Internal: true,
+			},
+			expectedDomain: "internal.custom.com",
+		},
+		{
+			name: "internal=false leaves domain unchanged",
+			config: Config{
+				Backend:  "e2b",
+				Domain:   "custom.com",
+				Internal: false,
+			},
+			expectedDomain: "custom.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetGlobals()
+			c := tt.config
+			resolveDeprecatedFields(&c)
+			if c.Domain != tt.expectedDomain {
+				t.Errorf("expected domain %q, got %q", tt.expectedDomain, c.Domain)
+			}
+		})
+	}
+}
+
+// TestSetInternal tests the SetInternal function's domain normalization behavior.
+func TestSetInternal(t *testing.T) {
+	tests := []struct {
+		name           string
+		initialDomain  string
+		setInternal    bool
+		expectedDomain string
+	}{
+		{
+			name:           "SetInternal(true) adds prefix",
+			initialDomain:  "tencentags.com",
+			setInternal:    true,
+			expectedDomain: "internal.tencentags.com",
+		},
+		{
+			name:           "SetInternal(true) does not double-prepend",
+			initialDomain:  "internal.tencentags.com",
+			setInternal:    true,
+			expectedDomain: "internal.tencentags.com",
+		},
+		{
+			name:           "SetInternal(false) removes prefix",
+			initialDomain:  "internal.tencentags.com",
+			setInternal:    false,
+			expectedDomain: "tencentags.com",
+		},
+		{
+			name:           "SetInternal(false) leaves domain without prefix unchanged",
+			initialDomain:  "tencentags.com",
+			setInternal:    false,
+			expectedDomain: "tencentags.com",
+		},
+		{
+			name:           "SetInternal(true) with custom domain",
+			initialDomain:  "custom.example.com",
+			setInternal:    true,
+			expectedDomain: "internal.custom.example.com",
+		},
+		{
+			name:           "SetInternal(false) removes prefix from custom domain",
+			initialDomain:  "internal.custom.example.com",
+			setInternal:    false,
+			expectedDomain: "custom.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetGlobals()
+			cfg = &Config{
+				Domain: tt.initialDomain,
+			}
+			SetInternal(tt.setInternal)
+			if cfg.Domain != tt.expectedDomain {
+				t.Errorf("expected domain %q, got %q", tt.expectedDomain, cfg.Domain)
+			}
+			if cfg.Internal != tt.setInternal {
+				t.Errorf("expected internal=%v, got %v", tt.setInternal, cfg.Internal)
+			}
+		})
+	}
+}
+
+// TestSetDomain tests the SetDomain function's normalization with internal flag.
+func TestSetDomain(t *testing.T) {
+	tests := []struct {
+		name            string
+		initialInternal bool
+		initialDomain   string
+		newDomain       string
+		expectedDomain  string
+	}{
+		{
+			name:            "SetDomain with internal=false keeps domain as-is",
+			initialInternal: false,
+			initialDomain:   defaultDomain,
+			newDomain:       "custom.com",
+			expectedDomain:  "custom.com",
+		},
+		{
+			name:            "SetDomain with internal=true adds prefix",
+			initialInternal: true,
+			initialDomain:   "internal." + defaultDomain,
+			newDomain:       "custom.com",
+			expectedDomain:  "internal.custom.com",
+		},
+		{
+			name:            "SetDomain with internal=true and domain already has prefix",
+			initialInternal: true,
+			initialDomain:   "internal." + defaultDomain,
+			newDomain:       "internal.custom.com",
+			expectedDomain:  "internal.custom.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetGlobals()
+			cfg = &Config{
+				Internal: tt.initialInternal,
+				Domain:   tt.initialDomain,
+			}
+			SetDomain(tt.newDomain)
+			if cfg.Domain != tt.expectedDomain {
+				t.Errorf("expected domain %q, got %q", tt.expectedDomain, cfg.Domain)
+			}
+		})
+	}
+}
+
+// TestSetCloudInternal tests that SetCloudInternal syncs to top-level internal.
+func TestSetCloudInternal(t *testing.T) {
+	tests := []struct {
+		name             string
+		initialDomain    string
+		setInternal      bool
+		expectedInternal bool
+		expectedDomain   string
+	}{
+		{
+			name:             "SetCloudInternal(true) syncs to top-level",
+			initialDomain:    defaultDomain,
+			setInternal:      true,
+			expectedInternal: true,
+			expectedDomain:   "internal." + defaultDomain,
+		},
+		{
+			name:             "SetCloudInternal(false) syncs to top-level and removes prefix",
+			initialDomain:    "internal." + defaultDomain,
+			setInternal:      false,
+			expectedInternal: false,
+			expectedDomain:   defaultDomain,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetGlobals()
+			cfg = &Config{
+				Domain: tt.initialDomain,
+			}
+			SetCloudInternal(tt.setInternal)
+			if cfg.Internal != tt.expectedInternal {
+				t.Errorf("expected internal=%v, got %v", tt.expectedInternal, cfg.Internal)
+			}
+			if cfg.Cloud.Internal != tt.setInternal {
+				t.Errorf("expected cloud.internal=%v, got %v", tt.setInternal, cfg.Cloud.Internal)
+			}
+			if cfg.Domain != tt.expectedDomain {
+				t.Errorf("expected domain %q, got %q", tt.expectedDomain, cfg.Domain)
+			}
+		})
+	}
+}
+
+// TestEndpointMethods tests the endpoint construction methods.
+func TestEndpointMethods(t *testing.T) {
+	tests := []struct {
+		name                    string
+		config                  Config
+		expectedControlPlane    string
+		expectedDataPlaneDomain string
+		expectedDataPlaneRegion string
+		expectedE2BControlPlane string
+	}{
+		{
+			name: "default config",
+			config: Config{
+				Region: defaultRegion,
+				Domain: defaultDomain,
+			},
+			expectedControlPlane:    "ags.tencentcloudapi.com",
+			expectedDataPlaneDomain: defaultDomain,
+			expectedDataPlaneRegion: "ap-guangzhou.tencentags.com",
+			expectedE2BControlPlane: "https://api.ap-guangzhou.tencentags.com",
+		},
+		{
+			name: "internal mode",
+			config: Config{
+				Region:   defaultRegion,
+				Domain:   "internal." + defaultDomain,
+				Internal: true,
+			},
+			expectedControlPlane:    "ags.internal.tencentcloudapi.com",
+			expectedDataPlaneDomain: "internal." + defaultDomain,
+			expectedDataPlaneRegion: "ap-guangzhou.internal.tencentags.com",
+			expectedE2BControlPlane: "https://api.ap-guangzhou.internal.tencentags.com",
+		},
+		{
+			name: "custom region and domain",
+			config: Config{
+				Region: "ap-shanghai",
+				Domain: "custom.com",
+			},
+			expectedControlPlane:    "ags.tencentcloudapi.com",
+			expectedDataPlaneDomain: "custom.com",
+			expectedDataPlaneRegion: "ap-shanghai.custom.com",
+			expectedE2BControlPlane: "https://api.ap-shanghai.custom.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := tt.config
+			if got := c.ControlPlaneEndpoint(); got != tt.expectedControlPlane {
+				t.Errorf("ControlPlaneEndpoint() = %q, want %q", got, tt.expectedControlPlane)
+			}
+			if got := c.DataPlaneDomain(); got != tt.expectedDataPlaneDomain {
+				t.Errorf("DataPlaneDomain() = %q, want %q", got, tt.expectedDataPlaneDomain)
+			}
+			if got := c.DataPlaneRegionDomain(); got != tt.expectedDataPlaneRegion {
+				t.Errorf("DataPlaneRegionDomain() = %q, want %q", got, tt.expectedDataPlaneRegion)
+			}
+			if got := c.E2BControlPlaneEndpoint(); got != tt.expectedE2BControlPlane {
+				t.Errorf("E2BControlPlaneEndpoint() = %q, want %q", got, tt.expectedE2BControlPlane)
+			}
+		})
+	}
+}
+
+// TestValidate tests the config validation logic.
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    Config
+		expectErr bool
+	}{
+		{
+			name:      "invalid backend",
+			config:    Config{Backend: "invalid", Output: "text"},
+			expectErr: true,
+		},
+		{
+			name:      "invalid output",
+			config:    Config{Backend: "e2b", Output: "xml"},
+			expectErr: true,
+		},
+		{
+			name:      "e2b missing api key",
+			config:    Config{Backend: "e2b", Output: "text"},
+			expectErr: true,
+		},
+		{
+			name:      "e2b valid",
+			config:    Config{Backend: "e2b", Output: "text", E2B: E2BConfig{APIKey: "key"}},
+			expectErr: false,
+		},
+		{
+			name:      "cloud missing credentials",
+			config:    Config{Backend: "cloud", Output: "text"},
+			expectErr: true,
+		},
+		{
+			name: "cloud valid",
+			config: Config{
+				Backend: "cloud", Output: "text",
+				Cloud: CloudConfig{SecretID: "id", SecretKey: "key"},
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetGlobals()
+			cfg = &tt.config
+			err := Validate()
+			if tt.expectErr && err == nil {
+				t.Error("expected error but got none")
+			}
+			if !tt.expectErr && err != nil {
+				t.Errorf("expected no error but got: %v", err)
+			}
+		})
+	}
+}

--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -337,7 +337,9 @@ var (
 		{Text: "--backend", Description: "API backend (e2b or cloud)"},
 		{Text: "-o", Description: "Output format (text or json)"},
 		{Text: "--output", Description: "Output format (text or json)"},
-		{Text: "--cloud-internal", Description: "Use internal endpoints"},
+		{Text: "--region", Description: "Region for API access"},
+		{Text: "--domain", Description: "Base domain"},
+		{Text: "--internal", Description: "Use internal endpoints"},
 	}
 )
 
@@ -889,7 +891,9 @@ Browser Sandbox:
 Global Flags:
   --backend <e2b|cloud>       API backend to use
   -o, --output <text|json>    Output format
-  --cloud-internal            Use internal endpoints (Tencent Cloud internal network)
+  --region <region>           Region for API access (default: ap-guangzhou)
+  --domain <domain>           Base domain (default: tencentags.com)
+  --internal                  Use internal endpoints (Tencent Cloud internal network)
 
 JSON Output:
   Commands with --time flag include timing info in JSON output.

--- a/internal/webshell/manager.go
+++ b/internal/webshell/manager.go
@@ -171,7 +171,7 @@ func (m *manager) Download(ctx context.Context, instanceID string) error {
 		return fmt.Errorf("failed to get system architecture: %w", err)
 	}
 
-	arch := "x86_64"
+	var arch string
 	sysArch := strings.TrimSpace(string(result.Stdout))
 	switch sysArch {
 	case "aarch64", "arm64":
@@ -334,7 +334,7 @@ func (m *manager) UploadTTYD(ctx context.Context, instanceID string, ttydPath st
 	if err != nil {
 		return fmt.Errorf("failed to open ttyd binary file: %w", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	// Upload ttyd binary to sandbox
 	_, err = sandbox.Files.Write(ctx, "/tmp/ttyd", file, nil)
@@ -376,7 +376,7 @@ func validateTTYDBinary(ttydPath string) error {
 	if err != nil {
 		return fmt.Errorf("ttyd binary file is not readable: %w", err)
 	}
-	file.Close()
+	_ = file.Close()
 
 	// Check file size (ttyd should be at least 1MB, but not larger than 50MB)
 	if info.Size() < 1024*1024 {

--- a/internal/webshell/manager_test.go
+++ b/internal/webshell/manager_test.go
@@ -12,7 +12,7 @@ func TestValidateTTYDBinary(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Unify region/domain/internal settings

### Summary

Consolidate duplicated `region`, `domain`, and `internal` configuration fields from backend-specific `[e2b]` / `[cloud]` sections into unified top-level fields, reducing configuration complexity and ensuring consistent endpoint construction across all backends.

### Motivation

Previously, users had to set `e2b.region`, `e2b.domain`, `cloud.region`, and `cloud.internal` separately under each backend section, even though these values were almost always identical. This PR introduces top-level `region`, `domain`, and `internal` fields as the single source of truth.

### Changes

**Config & CLI**
- Add top-level `region`, `domain`, `internal` config fields with corresponding `--region`, `--domain`, `--internal` CLI flags and `AGS_REGION`, `AGS_DOMAIN`, `AGS_INTERNAL` env vars
- Deprecate `--e2b-region`, `--e2b-domain`, `--cloud-region`, `--cloud-internal` flags (with deprecation warnings)
- Add `resolveDeprecatedFields()` to migrate legacy fields with clear priority: top-level > current-backend legacy > cross-backend fallback > default
- Normalize `internal` flag into `domain` at config resolution time (`internal=true` → `domain = "internal." + domain`), so downstream code only reads `domain`
- Use `viper.IsSet("internal")` to distinguish explicit `internal=false` from the default zero value

**Client Layer**
- All data-plane and control-plane clients now read from unified `config.GetRegion()` / `config.GetDomain()` instead of backend-specific accessors

**Docs & Config**
- Add `docs/ags-config.md` / `docs/ags-config-zh.md` — dedicated configuration reference
- Update `config.example.toml` with unified fields and deprecation notes
- Update CLI docs (`ags.md`, `ags-zh.md`) with new flags

**Tests**
- Add 31 unit tests covering `resolveDeprecatedFields`, setter functions, endpoint construction, and validation (all priority/branch combinations from the review checklist)

### Backward Compatibility

All deprecated fields and flags remain functional with automatic migration. A deprecation warning is printed to stderr when legacy fields are used. No breaking changes.
