### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG-zh.md
+++ b/CHANGELOG-zh.md
@@ -4,6 +4,8 @@
 
 ## [未发布]
 
+## [0.2.1] - 2026-03-13
+
 ### 变更
 - 扩展支持的工具类型，从 `code-interpreter` 和 `browser` 扩展为同时支持 `mobile`、`osworld`、`custom`、`swebench`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-03-13
+
 ### Changed
 - Expand supported tool types from `code-interpreter` and `browser` to also include `mobile`, `osworld`, `custom`, and `swebench`
 


### PR DESCRIPTION
## Release v0.2.1

### Changed
- Expand supported tool types from `code-interpreter` and `browser` to also include `mobile`, `osworld`, `custom`, and `swebench`

### 变更
- 扩展支持的工具类型，从 `code-interpreter` 和 `browser` 扩展为同时支持 `mobile`、`osworld`、`custom`、`swebench`