### PR TITLE
fix(api): use tool-id in instance create

### DIFF
--- a/CHANGELOG-zh.md
+++ b/CHANGELOG-zh.md
@@ -7,6 +7,9 @@
 ### 新增
 - 为 `instance login` 命令添加 `--mode` 参数，支持 `pty`（默认）和 `webshell` 两种模式；PTY 模式在当前终端中直接开启原生终端会话，无需浏览器或 ttyd 二进制文件
 
+### 修复
+- 修复 `instance create --tool-id` 未传递给 Cloud 后端 API 的问题；现在指定 ToolID 时优先使用 ToolID 而非 ToolName
+
 ## [0.2.1] - 2026-03-13
 
 ### 变更

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Add `--mode` flag to `instance login` command with `pty` (default) and `webshell` modes; PTY mode connects a native terminal session directly in the current console without requiring a browser or ttyd binary
 
+### Fixed
+- Fix `instance create --tool-id` not being passed to Cloud backend API; ToolID is now preferred over ToolName when specified
+
 ## [0.2.1] - 2026-03-13
 
 ### Changed

--- a/internal/client/cloud_instance.go
+++ b/internal/client/cloud_instance.go
@@ -40,11 +40,6 @@ func NewCloudInstanceClient(cfg *config.Config, cloudCfg *config.CloudConfig) (*
 
 // CreateInstance creates a new sandbox instance
 func (c *CloudInstanceClient) CreateInstance(ctx context.Context, opts *CreateInstanceOptions) (*Instance, error) {
-	toolName := opts.ToolName
-	if toolName == "" {
-		toolName = "code-interpreter-v1"
-	}
-
 	// Set timeout duration
 	timeout := time.Duration(opts.Timeout) * time.Second
 	if timeout == 0 {
@@ -52,7 +47,17 @@ func (c *CloudInstanceClient) CreateInstance(ctx context.Context, opts *CreateIn
 	}
 
 	request := ags.NewStartSandboxInstanceRequest()
-	request.ToolName = &toolName
+
+	// Prefer ToolID over ToolName when both or either are specified
+	if opts.ToolID != "" {
+		request.ToolId = &opts.ToolID
+	} else {
+		toolName := opts.ToolName
+		if toolName == "" {
+			toolName = "code-interpreter-v1"
+		}
+		request.ToolName = &toolName
+	}
 
 	// Set timeout
 	timeoutStr := formatDuration(timeout)


### PR DESCRIPTION
## fix(api): use tool-id in instance create

### Summary

Fix `instance create --tool-id` flag not being passed to the Cloud backend API. When a ToolID is specified, it is now preferred over ToolName.

### Changes

- **`internal/client/cloud_instance.go`**: Update `CreateInstance` to prefer `ToolID` over `ToolName` when both or either are specified. When `ToolID` is provided, it is sent via `request.ToolId`; otherwise falls back to `ToolName` (defaulting to `code-interpreter-v1`).
- **`CHANGELOG.md`** / **`CHANGELOG-zh.md`**: Add Fixed entry under `[Unreleased]`.

### Backward Compatibility

No breaking changes. The existing `--tool-name` flag continues to work as before when `--tool-id` is not specified.