### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG-zh.md
+++ b/CHANGELOG-zh.md
@@ -4,8 +4,12 @@
 
 ## [未发布]
 
+## [0.3.0] - 2026-03-17
+
 ### 新增
+- 新增 `mobile` 命令组（`ags mobile`），包含 `connect`、`disconnect`、`list`、`adb`、`tunnel` 子命令，通过加密 WebSocket 隧道安全访问远程 Android 沙箱的 ADB
 - 为 `instance login` 命令添加 `--mode` 参数，支持 `pty`（默认）和 `webshell` 两种模式；PTY 模式在当前终端中直接开启原生终端会话，无需浏览器或 ttyd 二进制文件
+- 新增移动端 ADB 命令的中英文文档
 
 ### 修复
 - 修复 `instance create --tool-id` 未传递给 Cloud 后端 API 的问题；现在指定 ToolID 时优先使用 ToolID 而非 ToolName

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-03-17
+
 ### Added
+- Add `mobile` command group (`ags mobile`) with `connect`, `disconnect`, `list`, `adb`, and `tunnel` subcommands for secure ADB access to remote Android sandboxes through encrypted WebSocket tunnels
 - Add `--mode` flag to `instance login` command with `pty` (default) and `webshell` modes; PTY mode connects a native terminal session directly in the current console without requiring a browser or ttyd binary
+- Add mobile ADB command documentation in both English and Chinese
 
 ### Fixed
 - Fix `instance create --tool-id` not being passed to Cloud backend API; ToolID is now preferred over ToolName when specified


### PR DESCRIPTION
## Release v0.3.0

### Added
- Add `mobile` command group (`ags mobile`) with `connect`, `disconnect`, `list`, `adb`, and `tunnel` subcommands for secure ADB access to remote Android sandboxes through encrypted WebSocket tunnels
- Add `--mode` flag to `instance login` command with `pty` (default) and `webshell` modes; PTY mode connects a native terminal session directly in the current console without requiring a browser or ttyd binary
- Add mobile ADB command documentation in both English and Chinese

### Fixed
- Fix `instance create --tool-id` not being passed to Cloud backend API; ToolID is now preferred over ToolName when specified

---

Once merged, GitHub Actions will automatically create the `v0.3.0` tag and GitHub Release.