### PR TITLE
fix: send tunnel daemon error messages via stdout instead of stderr

### DIFF
--- a/CHANGELOG-zh.md
+++ b/CHANGELOG-zh.md
@@ -4,6 +4,9 @@
 
 ## [未发布]
 
+### 修复
+- 修复 `mobile connect` 仅显示通用错误 "tunnel process exited without ready message" 而非实际错误信息的问题；daemon 子进程现在通过 stdout 发送错误详情，使父进程能向用户展示真实错误原因
+
 ## [0.3.1] - 2026-03-18
 
 ### 修复

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Fix `mobile connect` showing generic "tunnel process exited without ready message" instead of the actual error; daemon subprocess now sends error details via stdout so the parent process can display them to the user
+
 ## [0.3.1] - 2026-03-18
 
 ### Fixed

--- a/cmd/mobile.go
+++ b/cmd/mobile.go
@@ -180,11 +180,19 @@ func runMobileTunnel(_ *cobra.Command, args []string) error {
 		Insecure:      false,
 	})
 	if err != nil {
+		if daemonFlag {
+			errMsg := readyMessage{Status: "error", Message: fmt.Sprintf("failed to create tunnel: %v", err)}
+			_ = json.NewEncoder(os.Stdout).Encode(errMsg)
+		}
 		return exitError(1, fmt.Errorf("failed to create tunnel: %w", err))
 	}
 
 	addr, err := tunnel.Start()
 	if err != nil {
+		if daemonFlag {
+			errMsg := readyMessage{Status: "error", Message: fmt.Sprintf("failed to start tunnel: %v", err)}
+			_ = json.NewEncoder(os.Stdout).Encode(errMsg)
+		}
 		return exitError(3, fmt.Errorf("failed to start tunnel: %w", err))
 	}
 
@@ -193,7 +201,7 @@ func runMobileTunnel(_ *cobra.Command, args []string) error {
 		tunnel.Stop()
 		if daemonFlag {
 			errMsg := readyMessage{Status: "error", Message: err.Error()}
-			_ = json.NewEncoder(os.Stderr).Encode(errMsg)
+			_ = json.NewEncoder(os.Stdout).Encode(errMsg)
 		}
 		return exitError(2, fmt.Errorf("upstream probe failed: %w", err))
 	}


### PR DESCRIPTION
The tunnel subprocess in daemon mode was writing error JSON to stderr, but the parent process only reads from stdout. This caused the parent to show a generic "tunnel process exited without ready message" error instead of the actual failure reason (e.g., sandbox not found, auth failure). Also add error reporting for tunnel creation and start failures in daemon mode.