### PR TITLE
feat(instance): add --no-auth flag to 'instance login' command

### DIFF
--- a/CHANGELOG-zh.md
+++ b/CHANGELOG-zh.md
@@ -4,6 +4,9 @@
 
 ## [未发布]
 
+### 新增
+- 为 `instance login` 命令添加 `--no-auth` 参数，用于跳过 access token 获取并省略 token 请求头 / URL 参数，适用于数据面无需 access token 的部署环境
+
 ### 修复
 - 修复 `mobile connect` 仅显示通用错误 "tunnel process exited without ready message" 而非实际错误信息的问题；daemon 子进程现在通过 stdout 发送错误详情，使父进程能向用户展示真实错误原因
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Add `--no-auth` flag to `instance login` command to skip access-token acquisition and omit the token header / URL parameter, for environments where the data plane does not require an access token
+
 ### Fixed
 - Fix `mobile connect` showing generic "tunnel process exited without ready message" instead of the actual error; daemon subprocess now sends error details via stdout so the parent process can display them to the user
 

--- a/cmd/instance.go
+++ b/cmd/instance.go
@@ -36,6 +36,7 @@ var (
 	instanceLoginNoBrowser  bool
 	instanceLoginTTYDBinary string
 	instanceLoginUser       string
+	instanceLoginNoAuth     bool
 )
 
 // instanceCreateCmd represents the instance create command
@@ -574,7 +575,14 @@ Webshell mode (--mode webshell):
 
   ags instance login abc123 --mode webshell
   ags instance login abc123 --mode webshell --no-browser
-  ags instance login abc123 --mode webshell --ttyd-binary /path/to/ttyd`,
+  ags instance login abc123 --mode webshell --ttyd-binary /path/to/ttyd
+
+Use --no-auth to skip access-token acquisition and omit the token header / URL
+parameter. This is intended for environments where the data plane does not
+require an access token (e.g., a private deployment with authentication
+disabled).
+
+  ags instance login abc123 --no-auth`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
@@ -618,10 +626,16 @@ Webshell mode (--mode webshell):
 			}
 		}
 
-		// Get access token from cache or acquire new one
-		accessToken, err := GetCachedTokenOrAcquire(ctx, instanceID)
-		if err != nil {
-			return fmt.Errorf("failed to get access token: %w", err)
+		// Get access token from cache or acquire new one.
+		// When --no-auth is set, skip token acquisition entirely and use an
+		// empty token; downstream components will then avoid setting the
+		// X-Access-Token header / access_token URL parameter.
+		var accessToken string
+		if !instanceLoginNoAuth {
+			accessToken, err = GetCachedTokenOrAcquire(ctx, instanceID)
+			if err != nil {
+				return fmt.Errorf("failed to get access token: %w", err)
+			}
 		}
 
 		// Determine data plane domain
@@ -767,11 +781,16 @@ Webshell mode (--mode webshell):
 	},
 }
 
-// buildWebshellURL builds webshell access URL
+// buildWebshellURL builds webshell access URL.
 // Format: https://{port}-{instance_id}.{region}.{domain}/?access_token={token}
+// When accessToken is empty (e.g., --no-auth), the access_token query
+// parameter is omitted.
 func buildWebshellURL(instanceID, accessToken string) string {
 	cfg := config.Get()
 	host := fmt.Sprintf("8080-%s.%s.%s", instanceID, cfg.Region, cfg.DataPlaneDomain())
+	if accessToken == "" {
+		return fmt.Sprintf("https://%s/", host)
+	}
 	return fmt.Sprintf("https://%s/?access_token=%s", host, accessToken)
 }
 
@@ -878,6 +897,7 @@ func addInstanceCommand(parent *cobra.Command) {
 	loginCmd.Flags().BoolVar(&instanceLoginNoBrowser, "no-browser", false, "Don't open browser automatically (webshell mode)")
 	loginCmd.Flags().StringVar(&instanceLoginTTYDBinary, "ttyd-binary", "", "Path to custom ttyd binary file to upload (webshell mode)")
 	loginCmd.Flags().StringVar(&instanceLoginUser, "user", "", "User to run terminal as (default: \"user\")")
+	loginCmd.Flags().BoolVar(&instanceLoginNoAuth, "no-auth", false, "Skip access-token acquisition and omit the token header / URL parameter")
 	loginCmd.Flags().BoolVar(&instanceTime, "time", false, "Print elapsed time")
 	cmd.AddCommand(loginCmd)
 

--- a/cmd/instance_test.go
+++ b/cmd/instance_test.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+// TestBuildWebshellURL verifies that buildWebshellURL correctly includes
+// the access_token query parameter when a token is provided, and omits it
+// entirely when the token is empty (i.e., --no-auth mode).
+func TestBuildWebshellURL(t *testing.T) {
+	// Snapshot current config and restore after the test to avoid cross-test
+	// pollution.
+	original := *config.Get()
+	t.Cleanup(func() {
+		*config.Get() = original
+	})
+
+	cfg := config.Get()
+	cfg.Region = "ap-guangzhou"
+	cfg.Domain = "tencentags.com"
+	cfg.Internal = false
+
+	tests := []struct {
+		name        string
+		instanceID  string
+		accessToken string
+		want        string
+	}{
+		{
+			name:        "with token",
+			instanceID:  "sbi-abc123",
+			accessToken: "tok-xyz",
+			want:        "https://8080-sbi-abc123.ap-guangzhou.tencentags.com/?access_token=tok-xyz",
+		},
+		{
+			name:        "empty token omits access_token parameter",
+			instanceID:  "sbi-abc123",
+			accessToken: "",
+			want:        "https://8080-sbi-abc123.ap-guangzhou.tencentags.com/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildWebshellURL(tt.instanceID, tt.accessToken)
+			if got != tt.want {
+				t.Errorf("buildWebshellURL(%q, %q) = %q, want %q",
+					tt.instanceID, tt.accessToken, got, tt.want)
+			}
+			if tt.accessToken == "" && strings.Contains(got, "access_token") {
+				t.Errorf("expected no access_token parameter when token is empty, got %q", got)
+			}
+		})
+	}
+}
+
+// TestInstanceLoginNoAuthFlag verifies that the --no-auth flag is wired up on
+// the instance login command with the expected default and usage.
+func TestInstanceLoginNoAuthFlag(t *testing.T) {
+	instCmd := findSubcommand(rootCmd, "instance")
+	if instCmd == nil {
+		t.Fatal("instance command not registered on rootCmd")
+	}
+	loginCmd := findSubcommand(instCmd, "login")
+	if loginCmd == nil {
+		t.Fatal("instance login command not registered")
+	}
+
+	flag := loginCmd.Flags().Lookup("no-auth")
+	if flag == nil {
+		t.Fatal("--no-auth flag not registered on instance login")
+	}
+	if flag.DefValue != "false" {
+		t.Errorf("--no-auth default = %q, want \"false\"", flag.DefValue)
+	}
+	if !strings.Contains(strings.ToLower(flag.Usage), "token") {
+		t.Errorf("--no-auth usage should mention token, got %q", flag.Usage)
+	}
+}
+
+// findSubcommand returns the direct child command with the given name, or nil.
+func findSubcommand(parent *cobra.Command, name string) *cobra.Command {
+	for _, c := range parent.Commands() {
+		if c.Name() == name {
+			return c
+		}
+	}
+	return nil
+}

--- a/docs/ags-instance-zh.md
+++ b/docs/ags-instance-zh.md
@@ -154,6 +154,7 @@ ags i login <instance-id> [选项]
 | `--no-browser` | bool | `false` | 不自动打开浏览器（webshell 模式） |
 | `--ttyd-binary` | string | - | 要上传的自定义 ttyd 二进制文件路径（webshell 模式） |
 | `--user` | string | `user` | 运行终端的用户身份 |
+| `--no-auth` | bool | `false` | 跳过 access token 获取，并省略 token 请求头 / URL 参数 |
 | `--time` | bool | `false` | 显示耗时 |
 
 ### 支持的实例类型
@@ -182,6 +183,9 @@ ags i login sbi-xxxxxxxx --mode webshell --no-browser
 
 # Webshell 模式：使用自定义 ttyd 二进制文件（适用于网络受限环境）
 ags instance login sbi-xxxxxxxx --mode webshell --ttyd-binary /path/to/ttyd
+
+# 无鉴权模式：跳过 access token（适用于数据面无需 token 的部署）
+ags instance login sbi-xxxxxxxx --no-auth
 
 # 登录并显示耗时信息
 ags instance login sbi-xxxxxxxx --time

--- a/docs/ags-instance.md
+++ b/docs/ags-instance.md
@@ -154,6 +154,7 @@ Two modes are available:
 | `--no-browser` | bool | `false` | Don't open browser automatically (webshell mode) |
 | `--ttyd-binary` | string | - | Path to custom ttyd binary file to upload (webshell mode) |
 | `--user` | string | `user` | User to run terminal as |
+| `--no-auth` | bool | `false` | Skip access-token acquisition and omit the token header / URL parameter |
 | `--time` | bool | `false` | Print elapsed time |
 
 ### Supported Instance Types
@@ -182,6 +183,9 @@ ags i login sbi-xxxxxxxx --no-browser
 
 # Webshell mode: custom ttyd binary (for network-restricted environments)
 ags instance login sbi-xxxxxxxx --ttyd-binary /path/to/ttyd
+
+# No-auth mode: skip access token (for data planes that don't require one)
+ags instance login sbi-xxxxxxxx --no-auth
 
 # Login with timing information
 ags instance login sbi-xxxxxxxx --time

--- a/internal/pty/terminal.go
+++ b/internal/pty/terminal.go
@@ -81,7 +81,12 @@ func (s *Session) Connect(ctx context.Context, instanceID, user string) error {
 			},
 		},
 	})
-	startReq.Header().Set("X-Access-Token", s.accessToken)
+	// Only set the access-token header when a token is available. When the
+	// caller opts into --no-auth, s.accessToken is empty and we intentionally
+	// leave the header unset.
+	if s.accessToken != "" {
+		startReq.Header().Set("X-Access-Token", s.accessToken)
+	}
 	// Basic auth header selects the user inside the sandbox (same convention as the SDK)
 	startReq.Header().Set(
 		"Authorization",
@@ -264,6 +269,7 @@ func newProcessClient(envdHost string) processconnect.ProcessClient {
 }
 
 // sendPTYInput sends PTY keyboard data to a running process via the SendInput RPC.
+// When accessToken is empty, the X-Access-Token header is omitted.
 func sendPTYInput(ctx context.Context, cli processconnect.ProcessClient, pid uint32, data []byte, accessToken string) {
 	req := connect.NewRequest(&process.SendInputRequest{
 		Process: &process.ProcessSelector{
@@ -273,11 +279,14 @@ func sendPTYInput(ctx context.Context, cli processconnect.ProcessClient, pid uin
 			Input: &process.ProcessInput_Pty{Pty: data},
 		},
 	})
-	req.Header().Set("X-Access-Token", accessToken)
+	if accessToken != "" {
+		req.Header().Set("X-Access-Token", accessToken)
+	}
 	_, _ = cli.SendInput(ctx, req)
 }
 
 // resizePTY sends a PTY resize request for the given process.
+// When accessToken is empty, the X-Access-Token header is omitted.
 func resizePTY(ctx context.Context, cli processconnect.ProcessClient, pid uint32, cols, rows uint32, accessToken string) {
 	req := connect.NewRequest(&process.UpdateRequest{
 		Process: &process.ProcessSelector{
@@ -290,7 +299,9 @@ func resizePTY(ctx context.Context, cli processconnect.ProcessClient, pid uint32
 			},
 		},
 	})
-	req.Header().Set("X-Access-Token", accessToken)
+	if accessToken != "" {
+		req.Header().Set("X-Access-Token", accessToken)
+	}
 	_, _ = cli.Update(ctx, req)
 }
 

--- a/internal/pty/terminal_test.go
+++ b/internal/pty/terminal_test.go
@@ -1,0 +1,77 @@
+package pty
+
+import "testing"
+
+// TestNewSession_TokenPreserved ensures NewSession preserves the provided
+// access token (including the empty-string "no auth" case) and domain.
+func TestNewSession_TokenPreserved(t *testing.T) {
+	tests := []struct {
+		name        string
+		accessToken string
+		domain      string
+	}{
+		{
+			name:        "with token",
+			accessToken: "tok-abc",
+			domain:      "ap-guangzhou.tencentags.com",
+		},
+		{
+			name:        "empty token (no-auth mode)",
+			accessToken: "",
+			domain:      "ap-guangzhou.tencentags.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewSession(tt.accessToken, tt.domain)
+			if s == nil {
+				t.Fatal("NewSession returned nil")
+			}
+			if s.accessToken != tt.accessToken {
+				t.Errorf("accessToken = %q, want %q", s.accessToken, tt.accessToken)
+			}
+			if s.domain != tt.domain {
+				t.Errorf("domain = %q, want %q", s.domain, tt.domain)
+			}
+		})
+	}
+}
+
+// TestSession_EnvdHost verifies that envdHost builds the expected
+// region-qualified hostname for the given instance, and does not depend on
+// the access token (so --no-auth mode still resolves the correct URL).
+func TestSession_EnvdHost(t *testing.T) {
+	tests := []struct {
+		name        string
+		accessToken string
+		domain      string
+		instanceID  string
+		want        string
+	}{
+		{
+			name:        "with token",
+			accessToken: "tok-abc",
+			domain:      "ap-guangzhou.tencentags.com",
+			instanceID:  "sbi-123",
+			want:        "49983-sbi-123.ap-guangzhou.tencentags.com",
+		},
+		{
+			name:        "no-auth (empty token) produces same host",
+			accessToken: "",
+			domain:      "ap-guangzhou.tencentags.com",
+			instanceID:  "sbi-123",
+			want:        "49983-sbi-123.ap-guangzhou.tencentags.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewSession(tt.accessToken, tt.domain)
+			got := s.envdHost(tt.instanceID)
+			if got != tt.want {
+				t.Errorf("envdHost(%q) = %q, want %q", tt.instanceID, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -216,6 +216,7 @@ var (
 		{Text: "--no-browser", Description: "Don't open browser automatically"},
 		{Text: "--ttyd-binary", Description: "Path to custom ttyd binary file to upload"},
 		{Text: "--user", Description: "User to run terminal as"},
+		{Text: "--no-auth", Description: "Skip access-token acquisition and omit the token header / URL parameter"},
 		{Text: "--time", Description: "Print elapsed time to stderr"},
 	}
 


### PR DESCRIPTION
When --no-auth is set, skip access-token acquisition entirely and omit the X-Access-Token header (PTY mode) or the access_token URL parameter (webshell mode). This is intended for environments where the data plane does not require an access token, e.g. a private deployment with authentication disabled.

The flag defaults to false, preserving the existing behavior of resolving the token from cache or the control plane.

Also add unit tests covering buildWebshellURL (with and without token) and the PTY Session constructor / envd host resolution under the empty-token code path.