### PR TITLE
Feature/support noauth login

### DIFF
--- a/CHANGELOG-zh.md
+++ b/CHANGELOG-zh.md
@@ -4,6 +4,12 @@
 
 ## [未发布]
 
+### 新增
+- `Instance` 类型新增后端无关的 `Secure` 标识（Cloud 后端：`Secure = AuthMode != "NONE"`；E2B 后端：`Secure = envdAccessToken != ""`）；当实例不安全（无需 token）时，`ags instance login` 会跳过访问令牌的获取，并省略 `X-Access-Token` 请求头与 webshell URL 中的 `access_token` 查询参数，`ags instance create` 也不再因缓存令牌失败而报警告
+
+### 变更
+- 升级腾讯云 SDK（`tencentcloud-sdk-go/tencentcloud/ags` 与 `common`）至 v1.3.87，以获得沙箱实例新增的 `AuthMode` 字段
+
 ### 修复
 - 修复 `mobile connect` 仅显示通用错误 "tunnel process exited without ready message" 而非实际错误信息的问题；daemon 子进程现在通过 stdout 发送错误详情，使父进程能向用户展示真实错误原因
 

--- a/CHANGELOG-zh.md
+++ b/CHANGELOG-zh.md
@@ -6,6 +6,7 @@
 
 ### 新增
 - `Instance` 类型新增后端无关的 `Secure` 标识（Cloud 后端：`Secure = AuthMode != "NONE"`；E2B 后端：`Secure = envdAccessToken != ""`）；当实例不安全（无需 token）时，`ags instance login` 会跳过访问令牌的获取，并省略 `X-Access-Token` 请求头与 webshell URL 中的 `access_token` 查询参数，`ags instance create` 也不再因缓存令牌失败而报警告
+- 为 `ags instance create` / `ags instance start` 新增 `--auth-mode` 参数，取值 `DEFAULT`、`TOKEN`、`NONE`、`PUBLIC`；云端后端直接透传为 `AuthMode`，E2B 后端会自动转换为 `secure` + `network.allowPublicTraffic` 两个请求字段
 
 ### 变更
 - 升级腾讯云 SDK（`tencentcloud-sdk-go/tencentcloud/ags` 与 `common`）至 v1.3.87，以获得沙箱实例新增的 `AuthMode` 字段

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Surface a backend-agnostic `Secure` flag on the `Instance` type (Cloud: `Secure = AuthMode != "NONE"`; E2B: `Secure = envdAccessToken != ""`); `ags instance login` now skips access-token acquisition and omits the `X-Access-Token` header / webshell `access_token` query parameter when the instance is not secure, and `ags instance create` no longer fails to cache a token for such instances
+
+### Changed
+- Upgrade Tencent Cloud SDK (`tencentcloud-sdk-go/tencentcloud/ags` and `common`) to v1.3.87 to pick up the new `AuthMode` field on sandbox instances
+
 ### Fixed
 - Fix `mobile connect` showing generic "tunnel process exited without ready message" instead of the actual error; daemon subprocess now sends error details via stdout so the parent process can display them to the user
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Surface a backend-agnostic `Secure` flag on the `Instance` type (Cloud: `Secure = AuthMode != "NONE"`; E2B: `Secure = envdAccessToken != ""`); `ags instance login` now skips access-token acquisition and omits the `X-Access-Token` header / webshell `access_token` query parameter when the instance is not secure, and `ags instance create` no longer fails to cache a token for such instances
+- Add `--auth-mode` flag to `ags instance create` / `ags instance start` accepting `DEFAULT`, `TOKEN`, `NONE`, `PUBLIC`; cloud backend passes it through as `AuthMode`, while E2B backend translates it into the `secure` + `network.allowPublicTraffic` request fields
 
 ### Changed
 - Upgrade Tencent Cloud SDK (`tencentcloud-sdk-go/tencentcloud/ags` and `common`) to v1.3.87 to pick up the new `AuthMode` field on sandbox instances

--- a/cmd/instance.go
+++ b/cmd/instance.go
@@ -618,10 +618,16 @@ Webshell mode (--mode webshell):
 			}
 		}
 
-		// Get access token from cache or acquire new one
-		accessToken, err := GetCachedTokenOrAcquire(ctx, instanceID)
-		if err != nil {
-			return fmt.Errorf("failed to get access token: %w", err)
+		// Get access token from cache or acquire new one. When the instance
+		// is not secure (AuthMode=NONE on Cloud, or envdAccessToken empty on
+		// E2B), the data plane does not require (nor accept) a token, so we
+		// skip the token lookup entirely.
+		var accessToken string
+		if instance.Secure {
+			accessToken, err = GetCachedTokenOrAcquire(ctx, instanceID)
+			if err != nil {
+				return fmt.Errorf("failed to get access token: %w", err)
+			}
 		}
 
 		// Determine data plane domain
@@ -769,9 +775,13 @@ Webshell mode (--mode webshell):
 
 // buildWebshellURL builds webshell access URL
 // Format: https://{port}-{instance_id}.{region}.{domain}/?access_token={token}
+// When accessToken is empty (instance is not secure), the query parameter is omitted.
 func buildWebshellURL(instanceID, accessToken string) string {
 	cfg := config.Get()
 	host := fmt.Sprintf("8080-%s.%s.%s", instanceID, cfg.Region, cfg.DataPlaneDomain())
+	if accessToken == "" {
+		return fmt.Sprintf("https://%s/", host)
+	}
 	return fmt.Sprintf("https://%s/?access_token=%s", host, accessToken)
 }
 
@@ -887,7 +897,14 @@ func addInstanceCommand(parent *cobra.Command) {
 // cacheInstanceToken caches the access token for an instance.
 // For E2B backend, the token is returned during instance creation.
 // For Cloud backend, we need to call AcquireToken API.
+// When the instance is not secure, no token is required for data plane
+// access and this function is a no-op.
 func cacheInstanceToken(ctx context.Context, apiClient client.ControlPlaneClient, instance *client.Instance) error {
+	// Instances that don't require a token have nothing to cache.
+	if !instance.Secure {
+		return nil
+	}
+
 	tokenCache, err := token.NewCache()
 	if err != nil {
 		return fmt.Errorf("failed to create token cache: %w", err)

--- a/cmd/instance.go
+++ b/cmd/instance.go
@@ -22,6 +22,7 @@ var (
 	instanceTimeout      int
 	instanceTime         bool
 	instanceMountOptions []string
+	instanceAuthMode     string
 
 	// list command flags
 	instanceListTool     string
@@ -50,13 +51,20 @@ Use --tool-name/-t for tool name (e2b/cloud backend) or --tool-id for tool ID (c
 Mount option format (--mount-option):
   name=<name>[,dst=<target-path>][,subpath=<sub-path>][,readonly]
 
+Auth mode (--auth-mode):
+  DEFAULT  Use backend default (currently TOKEN)
+  TOKEN    All ports require X-Access-Token
+  PUBLIC   envd management port (49983) requires token; other ports open
+  NONE     No authentication on any port
+
 Examples:
   ags instance create -t code-interpreter-v1
   ags instance create --tool-name code-interpreter-v1
   ags instance create --tool code-interpreter-v1
   ags instance create --tool-id sdt-xxxx
   ags instance create -t my-tool --timeout 600
-  ags instance create --tool-id sdt-xxxx --mount-option "name=data,dst=/workspace,subpath=user-123"`,
+  ags instance create --tool-id sdt-xxxx --mount-option "name=data,dst=/workspace,subpath=user-123"
+  ags instance create -t my-tool --auth-mode NONE`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 		start := time.Now()
@@ -83,6 +91,12 @@ Examples:
 			mountOptions = append(mountOptions, *opt)
 		}
 
+		// Validate --auth-mode (empty means use backend default)
+		authMode, err := client.NormalizeAuthMode(instanceAuthMode)
+		if err != nil {
+			return fmt.Errorf("invalid --auth-mode: %w", err)
+		}
+
 		apiClient, err := client.NewControlPlaneClient(config.GetBackend())
 		if err != nil {
 			return fmt.Errorf("failed to create API client: %w", err)
@@ -93,6 +107,7 @@ Examples:
 			ToolName:     instanceTool,
 			Timeout:      instanceTimeout,
 			MountOptions: mountOptions,
+			AuthMode:     authMode,
 		}
 
 		instance, err := apiClient.CreateInstance(ctx, opts)
@@ -811,6 +826,7 @@ func addInstanceCommand(parent *cobra.Command) {
 	createCmd.Flags().IntVar(&instanceTimeout, "timeout", 300, "Instance timeout in seconds")
 	createCmd.Flags().BoolVar(&instanceTime, "time", false, "Print elapsed time to stderr")
 	createCmd.Flags().StringArrayVar(&instanceMountOptions, "mount-option", nil, "Mount option to override tool storage config\n"+client.FormatMountOptionHelp())
+	createCmd.Flags().StringVar(&instanceAuthMode, "auth-mode", client.AuthModeDefault, "Auth mode: DEFAULT, TOKEN, NONE, PUBLIC")
 	cmd.AddCommand(createCmd)
 
 	// start is an alias for create, but shown as separate command
@@ -826,6 +842,7 @@ func addInstanceCommand(parent *cobra.Command) {
 	startCmd.Flags().IntVar(&instanceTimeout, "timeout", 300, "Instance timeout in seconds")
 	startCmd.Flags().BoolVar(&instanceTime, "time", false, "Print elapsed time to stderr")
 	startCmd.Flags().StringArrayVar(&instanceMountOptions, "mount-option", nil, "Mount option to override tool storage config\n"+client.FormatMountOptionHelp())
+	startCmd.Flags().StringVar(&instanceAuthMode, "auth-mode", client.AuthModeDefault, "Auth mode: DEFAULT, TOKEN, NONE, PUBLIC")
 	cmd.AddCommand(startCmd)
 
 	listCmd := &cobra.Command{

--- a/docs/ags-instance-zh.md
+++ b/docs/ags-instance-zh.md
@@ -43,9 +43,23 @@ ags i c [选项]
 | `--tool-id` | string | - | 工具 ID（仅云端后端） |
 | `--timeout` | int | `300` | 实例超时时间（秒） |
 | `--mount-option` | string | - | 挂载选项覆盖（可重复） |
+| `--auth-mode` | string | - | 认证模式：`DEFAULT`、`TOKEN`、`NONE`、`PUBLIC` |
 | `--time` | bool | `false` | 显示耗时 |
 
 注意：必须指定 `--tool` 或 `--tool-id` 之一，但不能同时指定。
+
+### 认证模式
+
+`--auth-mode` 控制沙箱数据面是否要求访问令牌。云端与 E2B 后端均支持该参数；在 E2B 后端，CLI 会自动将该枚举转换为后端的 `secure` + `network.allowPublicTraffic` 字段。
+
+| 取值 | envd 管理端口（49983） | 业务端口 | 说明 |
+|------|------------------------|----------|------|
+| `DEFAULT` | 需要 token | 需要 token | 使用后端默认值（当前等价于 `TOKEN`） |
+| `TOKEN` | 需要 token | 需要 token | 全端口认证 |
+| `PUBLIC` | 需要 token | 免认证 | 对外开放业务流量，管理面仍受保护 |
+| `NONE` | 免认证 | 免认证 | 完全免认证 |
+
+以 `NONE` 创建的实例在 `ags instance login` 时会自动跳过令牌获取，不再发送 `X-Access-Token`。
 
 ### 挂载选项格式
 
@@ -75,6 +89,12 @@ ags instance create -t code-interpreter-v1 --timeout 3600
 # 创建时覆盖挂载选项
 ags instance create -t my-tool \
   --mount-option "name=data,dst=/workspace,subpath=user-123"
+
+# 创建一个全端口免认证的沙箱
+ags instance create -t my-tool --auth-mode NONE
+
+# 创建一个业务端口开放、管理面仍需 token 的沙箱
+ags instance create -t my-tool --auth-mode PUBLIC
 ```
 
 ## list

--- a/docs/ags-instance.md
+++ b/docs/ags-instance.md
@@ -43,9 +43,23 @@ ags i c [flags]
 | `--tool-id` | string | - | Tool ID (cloud backend only) |
 | `--timeout` | int | `300` | Instance timeout in seconds |
 | `--mount-option` | string | - | Mount option override (repeatable) |
+| `--auth-mode` | string | - | Auth mode: `DEFAULT`, `TOKEN`, `NONE`, `PUBLIC` |
 | `--time` | bool | `false` | Print elapsed time |
 
 Note: Must specify either `--tool` or `--tool-id`, but not both.
+
+### Auth Mode
+
+`--auth-mode` controls whether the sandbox data plane requires an access token. Both cloud and E2B backends support this flag; on E2B the CLI translates the enum into the backend's `secure` + `network.allowPublicTraffic` fields.
+
+| Value | envd management port (49983) | Application ports | Notes |
+|-------|-----------------------------|-------------------|-------|
+| `DEFAULT` | token required | token required | Backend default (currently equivalent to `TOKEN`) |
+| `TOKEN` | token required | token required | Full authentication |
+| `PUBLIC` | token required | open | Expose application traffic publicly |
+| `NONE` | open | open | No authentication at all |
+
+When the instance is created with `NONE`, `ags instance login` automatically skips token acquisition and does not send `X-Access-Token`.
 
 ### Mount Option Format
 
@@ -75,6 +89,13 @@ ags instance create -t code-interpreter-v1 --timeout 3600
 # Create with mount option override
 ags instance create -t my-tool \
   --mount-option "name=data,dst=/workspace,subpath=user-123"
+
+# Create a sandbox that requires no token on any port
+ags instance create -t my-tool --auth-mode NONE
+
+# Create a sandbox whose application ports are open but envd is still
+# protected by a token
+ags instance create -t my-tool --auth-mode PUBLIC
 ```
 
 ## list

--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ags v1.3.16
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.16
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ags v1.3.87
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.87
 	golang.org/x/term v0.41.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -67,10 +67,10 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ags v1.3.16 h1:FYmCDFjTq99TWW5mWZQ0qEgSOfyxUpeuza/5DNXgSBM=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ags v1.3.16/go.mod h1:I/z3lcJpFHSwZiKSl21KewJ22h1aWR3lybMVVek0OwQ=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.16 h1:NJG8cIsHwyCjwjIlm2migDdJpQ0l9it55jMPvxU064c=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.16/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ags v1.3.87 h1:WWIt7PwzHcFYLZnh+gNfuLMHCpqDhh9crtGZ8DbYw8U=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ags v1.3.87/go.mod h1:OzooRHDM7HgKMcFx32pf1/f7x13EilvPhyVElhPKK64=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.87 h1:NoQ9OD377kK5jF0Z0K305+8exY7KTlbFSu5MjQXsUPk=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.87/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=

--- a/internal/client/cloud_instance.go
+++ b/internal/client/cloud_instance.go
@@ -81,7 +81,7 @@ func (c *CloudInstanceClient) CreateInstance(ctx context.Context, opts *CreateIn
 	// Parse MountOptions from response
 	respMountOptions := parseAPIMountOptions(inst.MountOptions)
 
-	return &Instance{
+	result := &Instance{
 		ID:           derefString(inst.InstanceId),
 		ToolID:       derefString(inst.ToolId),
 		ToolName:     derefString(inst.ToolName),
@@ -89,7 +89,10 @@ func (c *CloudInstanceClient) CreateInstance(ctx context.Context, opts *CreateIn
 		CreatedAt:    derefString(inst.CreateTime),
 		Domain:       c.dataPlaneDomain,
 		MountOptions: respMountOptions,
-	}, nil
+		Secure:       !isAuthModeNone(inst.AuthMode),
+	}
+
+	return result, nil
 }
 
 // toAPIMountOptions converts client MountOptions to API format
@@ -236,9 +239,21 @@ func parseInstance(inst *ags.SandboxInstance, dataPlaneDomain string) Instance {
 		TimeoutSeconds: inst.TimeoutSeconds,
 		Domain:         dataPlaneDomain,
 		MountOptions:   parseAPIMountOptions(inst.MountOptions),
+		Secure:         !isAuthModeNone(inst.AuthMode),
 	}
 
 	return instance
+}
+
+// isAuthModeNone reports whether the Cloud control-plane AuthMode field
+// indicates that the sandbox data plane does not require a token.
+// A nil or empty AuthMode is treated as secure (token required), matching the
+// backend default (DEFAULT == TOKEN).
+func isAuthModeNone(authMode *string) bool {
+	if authMode == nil {
+		return false
+	}
+	return *authMode == "NONE"
 }
 
 // GetInstance returns a specific instance by ID

--- a/internal/client/cloud_instance.go
+++ b/internal/client/cloud_instance.go
@@ -68,6 +68,12 @@ func (c *CloudInstanceClient) CreateInstance(ctx context.Context, opts *CreateIn
 		request.MountOptions = toAPIMountOptions(opts.MountOptions)
 	}
 
+	// Set AuthMode if specified (empty = use backend default)
+	if opts.AuthMode != "" {
+		authMode := opts.AuthMode
+		request.AuthMode = &authMode
+	}
+
 	response, err := c.client.StartSandboxInstanceWithContext(ctx, request)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create instance: %w", err)

--- a/internal/client/e2b.go
+++ b/internal/client/e2b.go
@@ -139,6 +139,7 @@ func (c *E2BControlPlane) CreateInstance(ctx context.Context, opts *CreateInstan
 		CreatedAt:   time.Now().Format(time.RFC3339),
 		AccessToken: result.EnvdAccessToken,
 		Domain:      fmt.Sprintf("%s.%s", c.region, c.domain),
+		Secure:      result.EnvdAccessToken != "",
 	}, nil
 }
 
@@ -175,6 +176,10 @@ func (c *E2BControlPlane) ListInstances(ctx context.Context, opts *ListInstances
 			ToolName:  s.TemplateID,
 			Status:    "running",
 			CreatedAt: s.StartedAt,
+			// Secure is unknown from the list endpoint (no envdAccessToken
+			// field). Assume secure=true; callers that need an authoritative
+			// value should fetch the instance via GetInstance.
+			Secure: true,
 		}
 	}
 
@@ -221,6 +226,7 @@ func (c *E2BControlPlane) GetInstance(ctx context.Context, id string) (*Instance
 		CreatedAt:   result.StartedAt,
 		AccessToken: result.EnvdAccessToken,
 		Domain:      fmt.Sprintf("%s.%s", c.region, c.domain),
+		Secure:      result.EnvdAccessToken != "",
 	}, nil
 }
 

--- a/internal/client/e2b.go
+++ b/internal/client/e2b.go
@@ -112,6 +112,26 @@ func (c *E2BControlPlane) CreateInstance(ctx context.Context, opts *CreateInstan
 		"timeout":    timeout,
 	}
 
+	// Translate the unified AuthMode enum into the E2B request fields:
+	//   TOKEN   → secure=true,  network.allowPublicTraffic=false
+	//   PUBLIC  → secure=true,  network.allowPublicTraffic=true
+	//   NONE    → secure=false  (network is omitted; backend picks default)
+	//   DEFAULT (or empty) → leave both fields unset (backend default)
+	switch opts.AuthMode {
+	case AuthModeToken:
+		reqBody["secure"] = true
+		reqBody["network"] = map[string]any{"allowPublicTraffic": false}
+	case AuthModePublic:
+		reqBody["secure"] = true
+		reqBody["network"] = map[string]any{"allowPublicTraffic": true}
+	case AuthModeNone:
+		reqBody["secure"] = false
+	case "", AuthModeDefault:
+		// Use E2B backend default; do not set secure/network.
+	default:
+		return nil, fmt.Errorf("invalid auth mode %q for E2B backend", opts.AuthMode)
+	}
+
 	resp, err := c.doRequest(ctx, http.MethodPost, url, reqBody)
 	if err != nil {
 		return nil, err
@@ -126,6 +146,7 @@ func (c *E2BControlPlane) CreateInstance(ctx context.Context, opts *CreateInstan
 	var result struct {
 		SandboxID       string `json:"sandboxID"`
 		EnvdAccessToken string `json:"envdAccessToken"`
+		Secure          *bool  `json:"secure,omitempty"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
@@ -139,8 +160,19 @@ func (c *E2BControlPlane) CreateInstance(ctx context.Context, opts *CreateInstan
 		CreatedAt:   time.Now().Format(time.RFC3339),
 		AccessToken: result.EnvdAccessToken,
 		Domain:      fmt.Sprintf("%s.%s", c.region, c.domain),
-		Secure:      result.EnvdAccessToken != "",
+		Secure:      e2bSecure(result.Secure, result.EnvdAccessToken),
 	}, nil
+}
+
+// e2bSecure derives Instance.Secure from an E2B sandbox payload.
+// The explicit "secure" field wins when present; otherwise we fall back to
+// inferring secure=(envdAccessToken != "") for backward compatibility with
+// older backends that don't return the field.
+func e2bSecure(secure *bool, envdAccessToken string) bool {
+	if secure != nil {
+		return *secure
+	}
+	return envdAccessToken != ""
 }
 
 // ListInstances returns all sandbox instances
@@ -163,6 +195,7 @@ func (c *E2BControlPlane) ListInstances(ctx context.Context, opts *ListInstances
 		TemplateID string `json:"templateID"`
 		Alias      string `json:"alias"`
 		StartedAt  string `json:"startedAt"`
+		Secure     *bool  `json:"secure,omitempty"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&sandboxes); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
@@ -170,16 +203,21 @@ func (c *E2BControlPlane) ListInstances(ctx context.Context, opts *ListInstances
 
 	instances := make([]Instance, len(sandboxes))
 	for i, s := range sandboxes {
+		// The list endpoint doesn't return envdAccessToken. If the backend
+		// supplies "secure", use it; otherwise fall back to secure=true
+		// (token required) so callers don't silently drop auth. Consumers
+		// that need an authoritative value should fetch via GetInstance.
+		secure := true
+		if s.Secure != nil {
+			secure = *s.Secure
+		}
 		instances[i] = Instance{
 			ID:        s.SandboxID,
 			ToolID:    s.TemplateID,
 			ToolName:  s.TemplateID,
 			Status:    "running",
 			CreatedAt: s.StartedAt,
-			// Secure is unknown from the list endpoint (no envdAccessToken
-			// field). Assume secure=true; callers that need an authoritative
-			// value should fetch the instance via GetInstance.
-			Secure: true,
+			Secure:    secure,
 		}
 	}
 
@@ -213,6 +251,7 @@ func (c *E2BControlPlane) GetInstance(ctx context.Context, id string) (*Instance
 		StartedAt       string `json:"startedAt"`
 		State           string `json:"state"`
 		EnvdAccessToken string `json:"envdAccessToken"`
+		Secure          *bool  `json:"secure,omitempty"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
@@ -226,7 +265,7 @@ func (c *E2BControlPlane) GetInstance(ctx context.Context, id string) (*Instance
 		CreatedAt:   result.StartedAt,
 		AccessToken: result.EnvdAccessToken,
 		Domain:      fmt.Sprintf("%s.%s", c.region, c.domain),
-		Secure:      result.EnvdAccessToken != "",
+		Secure:      e2bSecure(result.Secure, result.EnvdAccessToken),
 	}, nil
 }
 

--- a/internal/client/types.go
+++ b/internal/client/types.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -200,12 +201,50 @@ type Instance struct {
 	Secure bool `json:"secure"`
 }
 
+// AuthMode values accepted by the control plane for sandbox instance
+// creation and returned in sandbox instance responses. They mirror the
+// Tencent Cloud API enumeration (StartSandboxInstance / SandboxInstance).
+const (
+	// AuthModeDefault falls back to the backend default, which currently
+	// means token authentication on every port (equivalent to AuthModeToken).
+	AuthModeDefault = "DEFAULT"
+	// AuthModeToken requires a token on all ports (management + application).
+	AuthModeToken = "TOKEN"
+	// AuthModeNone disables token authentication on all ports.
+	AuthModeNone = "NONE"
+	// AuthModePublic requires a token on the envd management port (49983)
+	// but leaves application ports open to unauthenticated traffic.
+	AuthModePublic = "PUBLIC"
+)
+
+// ValidAuthModes lists the AuthMode values accepted by the CLI.
+var ValidAuthModes = []string{
+	AuthModeDefault,
+	AuthModeToken,
+	AuthModeNone,
+	AuthModePublic,
+}
+
+// NormalizeAuthMode uppercases and validates an AuthMode string. An empty
+// input is returned as "" to signal "use backend default" (no value sent).
+func NormalizeAuthMode(s string) (string, error) {
+	if s == "" {
+		return "", nil
+	}
+	up := strings.ToUpper(strings.TrimSpace(s))
+	if slices.Contains(ValidAuthModes, up) {
+		return up, nil
+	}
+	return "", fmt.Errorf("invalid auth mode %q: must be one of %s", s, strings.Join(ValidAuthModes, ", "))
+}
+
 // CreateInstanceOptions represents options for creating an instance
 type CreateInstanceOptions struct {
 	ToolID       string
 	ToolName     string        // e.g., "code-interpreter-v1"
 	Timeout      int           // timeout in seconds
 	MountOptions []MountOption // Mount options to override tool defaults (optional)
+	AuthMode     string        // Optional DEFAULT / TOKEN / NONE / PUBLIC; empty = backend default
 }
 
 // ListInstancesOptions represents options for listing instances

--- a/internal/client/types.go
+++ b/internal/client/types.go
@@ -189,6 +189,15 @@ type Instance struct {
 	AccessToken    string        `json:"access_token,omitempty"`
 	Domain         string        `json:"domain,omitempty"`
 	MountOptions   []MountOption `json:"mount_options,omitempty"` // Mount options used by this instance
+
+	// Secure indicates whether the data plane requires a token (X-Access-Token
+	// header / webshell access_token query parameter) to access the sandbox.
+	// When false, the instance is open and no token should be sent.
+	//
+	// Backend mapping:
+	//   - Cloud backend: Secure = (AuthMode != "NONE")
+	//   - E2B backend:   Secure = (envdAccessToken != "")
+	Secure bool `json:"secure"`
 }
 
 // CreateInstanceOptions represents options for creating an instance

--- a/internal/pty/terminal.go
+++ b/internal/pty/terminal.go
@@ -81,7 +81,7 @@ func (s *Session) Connect(ctx context.Context, instanceID, user string) error {
 			},
 		},
 	})
-	startReq.Header().Set("X-Access-Token", s.accessToken)
+	setAccessToken(startReq.Header(), s.accessToken)
 	// Basic auth header selects the user inside the sandbox (same convention as the SDK)
 	startReq.Header().Set(
 		"Authorization",
@@ -273,7 +273,7 @@ func sendPTYInput(ctx context.Context, cli processconnect.ProcessClient, pid uin
 			Input: &process.ProcessInput_Pty{Pty: data},
 		},
 	})
-	req.Header().Set("X-Access-Token", accessToken)
+	setAccessToken(req.Header(), accessToken)
 	_, _ = cli.SendInput(ctx, req)
 }
 
@@ -290,8 +290,19 @@ func resizePTY(ctx context.Context, cli processconnect.ProcessClient, pid uint32
 			},
 		},
 	})
-	req.Header().Set("X-Access-Token", accessToken)
+	setAccessToken(req.Header(), accessToken)
 	_, _ = cli.Update(ctx, req)
+}
+
+// setAccessToken sets the X-Access-Token header when accessToken is non-empty.
+// A blank token means the target sandbox does not require authentication
+// (e.g. Cloud AuthMode=NONE or E2B instances without an envdAccessToken),
+// in which case the data plane does not require (and may reject) the header.
+func setAccessToken(h http.Header, accessToken string) {
+	if accessToken == "" {
+		return
+	}
+	h.Set("X-Access-Token", accessToken)
 }
 
 // termSize returns the current terminal width and height, defaulting to 220×50 on error.


### PR DESCRIPTION
- Surface a backend-agnostic `Secure` flag on the `Instance` type (Cloud: `Secure = AuthMode != "NONE"`; E2B: `Secure = envdAccessToken != ""`); `ags instance login` now skips access-token acquisition and omits the `X-Access-Token` header / webshell `access_token` query parameter when the instance is not secure, and `ags instance create` no longer fails to cache a token for such instances
- Add `--auth-mode` flag to `ags instance create` / `ags instance start` accepting `DEFAULT`, `TOKEN`, `NONE`, `PUBLIC`; cloud backend passes it through as `AuthMode`, while E2B backend translates it into the `secure` + `network.allowPublicTraffic` request fields