### PR TITLE
[DX] Update Go version requirement to 1.25.0 in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ For significant changes or new features, we recommend submitting a design propos
 
 ### Prerequisites
 
-- Go 1.21 or later
+- Go 1.25.0 or later
 - Make
 
 ### Building from Source


### PR DESCRIPTION
## Multica Issue

- Issue ID: AGE-808
- Priority: P1
- Type: DX Auto Fix

## Problem

CONTRIBUTING.md states the Go version requirement as "Go 1.21 or later", but go.mod requires `go 1.25.0`. This is a gap of 4 major versions. Contributors following the documentation would install Go 1.21, then immediately hit build failures when running `make build` or `go install`.

## Changes

- Updated CONTRIBUTING.md line 105: `Go 1.21 or later` → `Go 1.25.0 or later`

## Acceptance Criteria

- [x] CONTRIBUTING.md Go version requirement matches go.mod
- [x] Contributors installing Go based on documentation can successfully build the project

## Validation

- Docs manually checked: version now matches go.mod (`go 1.25.0`)
- No code changes, no tests or build needed

## Risk

Docs-only change. Zero compatibility risk. Corrects a misleading version requirement.

## Automation Note

This PR was generated by Agent Sandbox DX Auto Fix Agent based on multica issue AGE-808.