### PR TITLE
[DX] Upgrade alias step from Note to Required in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,20 @@ AGS CLI is a command-line tool for managing Tencent Cloud Agent Sandbox (AGS). I
 go install github.com/TencentCloudAgentRuntime/ags-cli@latest
 ```
 
-**Note**: The installed command will be `ags-cli`. If you prefer to use `ags` as the command name, you can create an alias:
+### Post-Installation (Required)
+
+The installed binary is named `ags-cli`, but all examples in this document use `ags`. Create an alias so the commands work:
 
 ```bash
 # Add to your shell configuration file (~/.zshrc, ~/.bashrc, etc.)
-alias ags='ags-cli'
-
-# Reload your shell configuration
+echo "alias ags='ags-cli'" >> ~/.zshrc
 source ~/.zshrc  # or source ~/.bashrc
+```
+
+Verify the alias works:
+
+```bash
+ags --version
 ```
 
 ### From Source


### PR DESCRIPTION
## Multica Issue

- Issue ID: AGE-814
- Priority: P2
- Type: DX Auto Fix

## Problem

After `go install`, the binary is named `ags-cli`, but all Quick Start commands and documentation use `ags`. The alias step was labeled as a **Note** at line 28, which users easily skip. Skipping it means every Quick Start command fails with "command not found" — this is the most basic first-time experience and directly drives users away.

## Changes

- Replaced the "Note" paragraph with a `### Post-Installation (Required)` heading
- Made the alias step explicit and actionable (uses `echo` to persist to shell config)
- Added a verification step (`ags --version`) so users confirm the alias works before proceeding

## Acceptance Criteria

- [x] Alias step is clearly marked as required, not optional
- [x] Users can seamlessly execute Quick Start commands after following the installation section
- [x] Verification step included

## Validation

- Docs manually checked: the flow from install → alias → Quick Start is now seamless
- No code changes, no tests or build needed

## Risk

Docs-only change. Zero compatibility risk. Improves first-time user experience.

## Automation Note

This PR was generated by Agent Sandbox DX Auto Fix Agent based on multica issue AGE-814.