### PR TITLE
fix(build): upgrade Go toolchain from 1.25.0 to 1.25.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/TencentCloudAgentRuntime/ags-cli
 
-go 1.25.0
+go 1.25.10
 
 require (
 	connectrpc.com/connect v1.18.1


### PR DESCRIPTION
## Summary

- Upgrades Go toolchain from 1.25.0 to 1.25.10 to address 20 known stdlib CVEs
- Fixes vulnerabilities in net/http, crypto/tls, crypto/x509, net/url, and other stdlib packages actively used by ags-cli code paths (proxy, adbtunnel, webshell)
- Toolchain-only change — no code modifications, single line diff in go.mod

## CVEs Addressed

Key high-severity vulnerabilities fixed:
- GO-2026-4918: net/http HTTP/2 infinite loop
- GO-2026-4870: crypto/tls
- GO-2026-4341: net/url
- GO-2026-4340: crypto/tls
- Plus 16 additional medium/low severity fixes

## Test plan

- [x] `go build ./...` passes cleanly
- [x] `go test ./...` — all tests pass
- [x] `go mod tidy` produces no additional changes
- [ ] CI pipeline picks up go1.25.10 via `go-version-file: go.mod`