### PR TITLE
chore: release v0.6.1

### DIFF
--- a/CHANGELOG-zh.md
+++ b/CHANGELOG-zh.md
@@ -2,6 +2,49 @@
 
 本项目的所有重要更改都将记录在此文件中。
 
+## [0.6.1] - 2026-06-05
+
+### 破坏性变更
+- 本版本没有破坏性变更。
+
+### 新功能
+- 本次发布无新功能。
+
+### Bug 修复
+- 修复 `agr instance debug` JSON flags（`--mount-options`、`--metadata`、`--custom-configuration`）现在正确支持 `@file` 和 `-`（标准输入）。
+- 修复 `agr instance debug` 文本输出中 `ToolID` 字段显示错误（显示输入的 flag 值而非新建的 debug tool ID）。
+- 修复 `agr instance debug --tool-name` 使用了错误的 API 字段名，现在正确使用 `Filters` 查询。
+- 修复 `agr instance debug` 传入无效 JSON 时显示 `internal error`，现在显示 `INVALID_JSON_FLAG` 并附带明确提示。
+- 修复 `agr instance login` 传入不存在的实例 ID 时显示 `internal error`，现在正确显示 `INSTANCE_NOT_FOUND`。
+- 修复 README 手动安装命令中文件名版本号错误（`agr-0.5.0-*` 应为 `agr-0.6.1-*`）。
+
+### 文档
+- 更新 README 中 `agr instance debug` 示例，使用 `--tool-id`/`--tool-name` flag 并移除不存在的 `--debug-tool-name` flag。
+
+## [0.6.0] - 2026-06-02
+
+### 破坏性变更
+- 本版本没有破坏性变更。
+
+### 新功能
+- 通过 `--token`、`TENCENTCLOUD_TOKEN` 和 `[auth].token` 支持腾讯云 STS 临时凭证认证。
+- `agr instance debug --tool-id <id>` — 基于现有沙箱工具创建临时 Debug Tool，自动挂载 envd 镜像并等待就绪后启动实例。
+- `agr tool fork <source-tool-id> --tool-name <new-name>` — 通过复制现有工具的可创建配置来新建工具，支持 flag 覆盖。
+- `agr instance list --all` — 自动翻页获取当前 region 的所有实例，输出中包含 region 信息。
+- 复杂 flag（`--filters`、`--tags`、`--network-configuration`、`--storage-mounts` 等）在 help 中新增 Format、Values 和 Examples 说明。
+- 命令 help 新增分组 `Example - ...:` 示例区块，`agr schema` 也暴露命令示例及复杂 flag 的格式/示例/取值元数据。
+
+### Bug 修复
+- 服务端错误现在在 CLI 输出中同时显示 `RequestId`、`Code` 和 `Message`，便于联系腾讯云支持时快速定位问题。
+- `agr instance login` 现在明确报告 PTY/envd 数据面会话失败，不再将其折叠为通用内部错误；用户输入 `exit` 时命令会透传远端 shell 的退出码，不再渲染错误信息（与 `ssh` 行为一致）。
+- `agr version` 现在能从 Go module 伪版本中提取 commit hash 和构建时间（适用于 `go install @latest` 安装的二进制），并对 `go install <module>@<tag>` 构建的二进制显示 `n/a (go install)` 而非 `unknown`。
+- `agr instance file upload`/`download` 收到 flag 格式路径参数时，错误提示改为具体的 positional 用法说明。
+- `agr tool fork` 和 `agr instance debug` 在复制工具时过滤掉 `qcs` 前缀的内部标签。
+- `agr schema instance.debug` 的元数据（`Mutation`、`CreatesResource`、`RequiresAuth`）现在正确返回 `true`。
+
+### 文档
+- 更新安装文档，推荐使用预编译 release 二进制，并说明 `go install` 构建的版本元数据行为。
+
 ## [0.5.1] - 2026-05-29
 
 ### 破坏性变更

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## [0.6.1] - 2026-06-05
+
+### Breaking Changes
+- This release has no Breaking Changes.
+
+### Features
+- This release has no new features.
+
+### Bug Fixes
+- Fix `agr instance debug` JSON flags (`--mount-options`, `--metadata`, `--custom-configuration`) now correctly support `@file` and `-` (stdin) as documented.
+- Fix `agr instance debug` text output showing wrong `ToolID` (showed input flag value instead of the created debug tool ID).
+- Fix `agr instance debug --tool-name` lookup using wrong API field; now uses `Filters` correctly.
+- Fix `agr instance debug` invalid JSON input showing `internal error`; now shows `INVALID_JSON_FLAG` with a clear hint.
+- Fix `agr instance login` with a non-existent instance ID showing `internal error` instead of `INSTANCE_NOT_FOUND`.
+- Fix README manual install commands referencing wrong filename version (`agr-0.5.0-*` instead of `agr-0.6.1-*`).
+
+### Docs
+- Update `agr instance debug` examples in README to use `--tool-id`/`--tool-name` flags and remove non-existent `--debug-tool-name` flag.
 
 ## [0.6.0] - 2026-06-02
 
@@ -13,7 +30,7 @@ All notable changes to this project will be documented in this file.
 - Tencent Cloud STS session tokens are now supported via `--token`,
   `TENCENTCLOUD_TOKEN`, and `[auth].token` for temporary AK/SK
   credentials. (Upstream-Issue: 15)
-- `agr instance debug <tool-id>` creates a debug tool from an existing
+- `agr instance debug --tool-id <id>` creates a debug tool from an existing
   sandbox tool by switching the startup command to `/envd` and adding
   the envd image mount. (Upstream-Issue: 3)
 - `agr tool fork <source-tool-id> --tool-name <new-tool-name>` creates a
@@ -53,10 +70,6 @@ All notable changes to this project will be documented in this file.
   `go install <module>@<tag>` (Go does not stamp VCS metadata for
   module-cache builds). Pseudo-version installs and ldflags-stamped
   release binaries are unchanged. (Upstream-Issue: 6)
-- `--jq` expressions now operate on the `Data` payload directly instead
-  of the wrapping envelope, consistent with `gh --jq` and `aws --query`
-  behavior (e.g. `.InstanceId` instead of `.Data.InstanceId`).
-  (Upstream-Issue: 10)
 - Live test binary builds now disable Go VCS stamping so race-test gate
   runs do not fail in worktrees where Git metadata cannot be inspected.
 - CI gofmt and changelog-gate failures resolved by formatting

--- a/README-zh.md
+++ b/README-zh.md
@@ -16,49 +16,56 @@ curl -fsSL https://github.com/TencentCloudAgentRuntime/ags-cli/releases/latest/d
 
 从 [GitHub Releases](https://github.com/TencentCloudAgentRuntime/ags-cli/releases) 下载最新版本并手动安装。
 
+将 `VERSION` 设置为目标版本号（如 `0.6.1`）：
+
 **macOS（Apple Silicon）**
 
 ```bash
-curl -fLO https://github.com/TencentCloudAgentRuntime/ags-cli/releases/download/v0.6.0/agr-0.6.0-darwin-arm64.tar.gz
-tar xzf agr-0.5.0-darwin-arm64.tar.gz
+VERSION=0.6.1
+curl -fLO https://github.com/TencentCloudAgentRuntime/ags-cli/releases/download/v${VERSION}/agr-${VERSION}-darwin-arm64.tar.gz
+tar xzf agr-${VERSION}-darwin-arm64.tar.gz
 sudo mv agr /usr/local/bin/agr
-rm agr-0.5.0-darwin-arm64.tar.gz
+rm agr-${VERSION}-darwin-arm64.tar.gz
 ```
 
 **macOS（Intel）**
 
 ```bash
-curl -fLO https://github.com/TencentCloudAgentRuntime/ags-cli/releases/download/v0.6.0/agr-0.6.0-darwin-amd64.tar.gz
-tar xzf agr-0.5.0-darwin-amd64.tar.gz
+VERSION=0.6.1
+curl -fLO https://github.com/TencentCloudAgentRuntime/ags-cli/releases/download/v${VERSION}/agr-${VERSION}-darwin-amd64.tar.gz
+tar xzf agr-${VERSION}-darwin-amd64.tar.gz
 sudo mv agr /usr/local/bin/agr
-rm agr-0.5.0-darwin-amd64.tar.gz
+rm agr-${VERSION}-darwin-amd64.tar.gz
 ```
 
 **Linux（x86_64）**
 
 ```bash
-curl -fLO https://github.com/TencentCloudAgentRuntime/ags-cli/releases/download/v0.6.0/agr-0.6.0-linux-amd64.tar.gz
-tar xzf agr-0.5.0-linux-amd64.tar.gz
+VERSION=0.6.1
+curl -fLO https://github.com/TencentCloudAgentRuntime/ags-cli/releases/download/v${VERSION}/agr-${VERSION}-linux-amd64.tar.gz
+tar xzf agr-${VERSION}-linux-amd64.tar.gz
 sudo mv agr /usr/local/bin/agr
-rm agr-0.5.0-linux-amd64.tar.gz
+rm agr-${VERSION}-linux-amd64.tar.gz
 ```
 
 **Linux（ARM64）**
 
 ```bash
-curl -fLO https://github.com/TencentCloudAgentRuntime/ags-cli/releases/download/v0.6.0/agr-0.6.0-linux-arm64.tar.gz
-tar xzf agr-0.5.0-linux-arm64.tar.gz
+VERSION=0.6.1
+curl -fLO https://github.com/TencentCloudAgentRuntime/ags-cli/releases/download/v${VERSION}/agr-${VERSION}-linux-arm64.tar.gz
+tar xzf agr-${VERSION}-linux-arm64.tar.gz
 sudo mv agr /usr/local/bin/agr
-rm agr-0.5.0-linux-arm64.tar.gz
+rm agr-${VERSION}-linux-arm64.tar.gz
 ```
 
 **Windows（x86_64）— PowerShell**
 
 ```powershell
-Invoke-WebRequest -Uri https://github.com/TencentCloudAgentRuntime/ags-cli/releases/download/v0.6.0/agr-0.6.0-windows-amd64.zip -OutFile agr-0.6.0-windows-amd64.zip
-Expand-Archive agr-0.6.0-windows-amd64.zip -DestinationPath .
+$VERSION = "0.6.1"
+Invoke-WebRequest -Uri "https://github.com/TencentCloudAgentRuntime/ags-cli/releases/download/v${VERSION}/agr-${VERSION}-windows-amd64.zip" -OutFile "agr-${VERSION}-windows-amd64.zip"
+Expand-Archive "agr-${VERSION}-windows-amd64.zip" -DestinationPath .
 Move-Item agr.exe "$env:USERPROFILE\bin\agr.exe"
-Remove-Item agr-0.6.0-windows-amd64.zip
+Remove-Item "agr-${VERSION}-windows-amd64.zip"
 ```
 
 > 请确保 `$env:USERPROFILE\bin` 在 `PATH` 中。
@@ -66,7 +73,8 @@ Remove-Item agr-0.6.0-windows-amd64.zip
 ### 校验下载文件
 
 ```bash
-curl -fLO https://github.com/TencentCloudAgentRuntime/ags-cli/releases/download/v0.6.0/checksums.txt
+VERSION=0.6.1
+curl -fLO https://github.com/TencentCloudAgentRuntime/ags-cli/releases/download/v${VERSION}/checksums.txt
 shasum -a 256 -c checksums.txt --ignore-missing
 ```
 
@@ -180,16 +188,16 @@ agr instance exec \
 
 ## Debug Tool 创建
 
-使用 `agr instance debug <tool-id>` 基于现有工具创建一份 Debug
-Tool。新工具会保留源工具配置，把启动命令改为 `/envd`，并将
+使用 `agr instance debug --tool-id` 或 `--tool-name` 基于现有工具创建一份
+Debug Tool。新工具会保留源工具配置，把启动命令改为 `/envd`，并将
 `ccr.ccs.tencentyun.com/ags-image/envd:v0.5.14` 镜像内的
 `/usr/bin/envd` 挂载到 `/envd`。源工具必须配置 `RoleArn`，因为
 镜像类型的存储挂载依赖该角色。
 
 ```bash
-debug_tool_id=$(agr instance debug "$tool_id" \
-  --debug-tool-name "my-tool-debug" \
-  -o json --jq '.Data.ToolId')
+debug_instance_id=$(agr instance debug --tool-id "$tool_id" \
+  --timeout 30m \
+  -o json --jq '.Data.InstanceId')
 ```
 
 ## 控制面端点与数据面域名
@@ -233,7 +241,7 @@ agr instance update <id>         更新 timeout / metadata
 agr instance pause <id>          暂停实例
 agr instance resume <id>         恢复实例
 agr instance delete <id>         删除实例
-agr instance debug <tool-id>     基于工具创建 Debug Tool
+agr instance debug --tool-id <id>  基于工具创建 Debug 实例
 
 agr instance code run <id>       在实例中执行代码
 agr instance exec <id> -- CMD    在实例中执行 shell 命令

--- a/README.md
+++ b/README.md
@@ -16,49 +16,56 @@ curl -fsSL https://github.com/TencentCloudAgentRuntime/ags-cli/releases/latest/d
 
 Download the latest release from [GitHub Releases](https://github.com/TencentCloudAgentRuntime/ags-cli/releases) and install manually.
 
+Set `VERSION` to the release you want (e.g. `0.6.1`):
+
 **macOS (Apple Silicon)**
 
 ```bash
-curl -fLO https://github.com/TencentCloudAgentRuntime/ags-cli/releases/download/v0.6.0/agr-0.6.0-darwin-arm64.tar.gz
-tar xzf agr-0.5.0-darwin-arm64.tar.gz
+VERSION=0.6.1
+curl -fLO https://github.com/TencentCloudAgentRuntime/ags-cli/releases/download/v${VERSION}/agr-${VERSION}-darwin-arm64.tar.gz
+tar xzf agr-${VERSION}-darwin-arm64.tar.gz
 sudo mv agr /usr/local/bin/agr
-rm agr-0.5.0-darwin-arm64.tar.gz
+rm agr-${VERSION}-darwin-arm64.tar.gz
 ```
 
 **macOS (Intel)**
 
 ```bash
-curl -fLO https://github.com/TencentCloudAgentRuntime/ags-cli/releases/download/v0.6.0/agr-0.6.0-darwin-amd64.tar.gz
-tar xzf agr-0.5.0-darwin-amd64.tar.gz
+VERSION=0.6.1
+curl -fLO https://github.com/TencentCloudAgentRuntime/ags-cli/releases/download/v${VERSION}/agr-${VERSION}-darwin-amd64.tar.gz
+tar xzf agr-${VERSION}-darwin-amd64.tar.gz
 sudo mv agr /usr/local/bin/agr
-rm agr-0.5.0-darwin-amd64.tar.gz
+rm agr-${VERSION}-darwin-amd64.tar.gz
 ```
 
 **Linux (x86_64)**
 
 ```bash
-curl -fLO https://github.com/TencentCloudAgentRuntime/ags-cli/releases/download/v0.6.0/agr-0.6.0-linux-amd64.tar.gz
-tar xzf agr-0.5.0-linux-amd64.tar.gz
+VERSION=0.6.1
+curl -fLO https://github.com/TencentCloudAgentRuntime/ags-cli/releases/download/v${VERSION}/agr-${VERSION}-linux-amd64.tar.gz
+tar xzf agr-${VERSION}-linux-amd64.tar.gz
 sudo mv agr /usr/local/bin/agr
-rm agr-0.5.0-linux-amd64.tar.gz
+rm agr-${VERSION}-linux-amd64.tar.gz
 ```
 
 **Linux (ARM64)**
 
 ```bash
-curl -fLO https://github.com/TencentCloudAgentRuntime/ags-cli/releases/download/v0.6.0/agr-0.6.0-linux-arm64.tar.gz
-tar xzf agr-0.5.0-linux-arm64.tar.gz
+VERSION=0.6.1
+curl -fLO https://github.com/TencentCloudAgentRuntime/ags-cli/releases/download/v${VERSION}/agr-${VERSION}-linux-arm64.tar.gz
+tar xzf agr-${VERSION}-linux-arm64.tar.gz
 sudo mv agr /usr/local/bin/agr
-rm agr-0.5.0-linux-arm64.tar.gz
+rm agr-${VERSION}-linux-arm64.tar.gz
 ```
 
 **Windows (x86_64) — PowerShell**
 
 ```powershell
-Invoke-WebRequest -Uri https://github.com/TencentCloudAgentRuntime/ags-cli/releases/download/v0.6.0/agr-0.6.0-windows-amd64.zip -OutFile agr-0.6.0-windows-amd64.zip
-Expand-Archive agr-0.6.0-windows-amd64.zip -DestinationPath .
+$VERSION = "0.6.1"
+Invoke-WebRequest -Uri "https://github.com/TencentCloudAgentRuntime/ags-cli/releases/download/v${VERSION}/agr-${VERSION}-windows-amd64.zip" -OutFile "agr-${VERSION}-windows-amd64.zip"
+Expand-Archive "agr-${VERSION}-windows-amd64.zip" -DestinationPath .
 Move-Item agr.exe "$env:USERPROFILE\bin\agr.exe"
-Remove-Item agr-0.6.0-windows-amd64.zip
+Remove-Item "agr-${VERSION}-windows-amd64.zip"
 ```
 
 > Make sure `$env:USERPROFILE\bin` is in your `PATH`.
@@ -66,7 +73,8 @@ Remove-Item agr-0.6.0-windows-amd64.zip
 ### Verify checksums
 
 ```bash
-curl -fLO https://github.com/TencentCloudAgentRuntime/ags-cli/releases/download/v0.6.0/checksums.txt
+VERSION=0.6.1
+curl -fLO https://github.com/TencentCloudAgentRuntime/ags-cli/releases/download/v${VERSION}/checksums.txt
 shasum -a 256 -c checksums.txt --ignore-missing
 ```
 
@@ -198,18 +206,17 @@ The JSON output of these commands includes
 
 ## Debug instance creation
 
-Use `agr instance debug <tool-id>` to create a debug instance for an existing
-tool. The command creates a temporary debug tool that keeps the source tool
-configuration, changes the startup command to `/envd`, mounts
-`ccr.ccs.tencentyun.com/ags-image/envd:v0.5.14` from `/usr/bin/envd` to
-`/envd`, waits for that tool to be ready, then starts an instance from it.
+Use `agr instance debug` with `--tool-id` or `--tool-name` to create a debug
+instance for an existing tool. The command creates a temporary debug tool that
+keeps the source tool configuration, changes the startup command to `/envd`,
+mounts `ccr.ccs.tencentyun.com/ags-image/envd:v0.5.14` from `/usr/bin/envd`
+to `/envd`, waits for that tool to be ready, then starts an instance from it.
 The source tool must have `RoleArn` configured because image storage mounts
 require it. `--timeout` controls the created instance lifetime and defaults
 to `1h`; readiness waits use the command's internal workflow timeout.
 
 ```bash
-debug_instance_id=$(agr instance debug "$tool_id" \
-  --debug-tool-name "my-tool-debug" \
+debug_instance_id=$(agr instance debug --tool-id "$tool_id" \
   --timeout 30m \
   -o json --jq '.Data.InstanceId')
 ```
@@ -254,7 +261,7 @@ agr instance update <id>         Update timeout/metadata
 agr instance pause <id>          Pause an instance
 agr instance resume <id>         Resume an instance
 agr instance delete <id>         Delete instance(s)
-agr instance debug <tool-id>     Create a debug instance from a tool
+agr instance debug --tool-id <id>  Create a debug instance from a tool
 
 agr instance code run <id>       Execute code in an existing instance
 agr instance exec <id> -- CMD    Execute shell command in an existing instance


### PR DESCRIPTION
## [0.6.1] - 2026-06-05

### Breaking Changes
- This release has no Breaking Changes.

### Features
- This release has no new features.

### Bug Fixes
- Fix `agr instance debug` JSON flags (`--mount-options`, `--metadata`, `--custom-configuration`) now correctly support `@file` and `-` (stdin) as documented.
- Fix `agr instance debug` text output showing wrong `ToolID` (showed input flag value instead of the created debug tool ID).
- Fix `agr instance debug --tool-name` lookup using wrong API field; now uses `Filters` correctly.
- Fix `agr instance debug` invalid JSON input showing `internal error`; now shows `INVALID_JSON_FLAG` with a clear hint.
- Fix `agr instance login` with a non-existent instance ID showing `internal error` instead of `INSTANCE_NOT_FOUND`.
- Fix README manual install commands referencing wrong filename version (`agr-0.5.0-*` instead of `agr-0.6.1-*`).

### Docs
- Update `agr instance debug` examples in README to use `--tool-id`/`--tool-name` flags and remove non-existent `--debug-tool-name` flag.
- Use `VERSION` variable in manual install instructions to avoid version drift between download URL and filename commands.

## After merge

Tag `v0.6.1` to trigger the release workflow:
```bash
git tag v0.6.1 && git push origin v0.6.1
