### PR TITLE
fix(build): produce statically linked Linux release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
             if [ "$GOOS" = "windows" ]; then ext=".zip"; bin="agr.exe"; fi
             work="dist/agr-${VERSION}-${GOOS}-${GOARCH}"
             mkdir -p "$work"
-            GOOS="$GOOS" GOARCH="$GOARCH" go build -ldflags "$LDFLAGS" -o "$work/$bin" ./cmd/agr
+            CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" go build -ldflags "$LDFLAGS" -o "$work/$bin" ./cmd/agr
             if [ "$GOOS" = "windows" ]; then
               (cd "$work" && zip -q "../agr-${VERSION}-${GOOS}-${GOARCH}${ext}" "$bin")
             else
@@ -94,6 +94,9 @@ jobs:
           /tmp/agr version
           /tmp/agr version -o json | tee /tmp/agr-version.json
           grep -q "\"Version\":\"${VERSION}\"" /tmp/agr-version.json
+          # Guard against dynamic glibc linkage regressing on release binaries
+          # (see fix for GLIBC_2.34 not found on older Linux distros).
+          file /tmp/agr | grep -q 'statically linked'
           # `agr api list-actions` was removed in §9.4 in favour of
           # `agr schema` for user-facing introspection; smoke a known
           # mapped command instead.

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@ build-linux:
 	@echo "Building for Linux..."
 	@mkdir -p $(BUILD_DIR)
 	@mkdir -p $(GOCACHE_DIR) $(GOTMPDIR_DIR)
-	$(GO_RUN_ENV) GOOS=linux GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-linux-amd64 ./cmd/agr
-	$(GO_RUN_ENV) GOOS=linux GOARCH=arm64 $(GOBUILD) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-linux-arm64 ./cmd/agr
+	$(GO_RUN_ENV) CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-linux-amd64 ./cmd/agr
+	$(GO_RUN_ENV) CGO_ENABLED=0 GOOS=linux GOARCH=arm64 $(GOBUILD) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-linux-arm64 ./cmd/agr
 
 build-darwin:
 	@echo "Building for macOS..."


### PR DESCRIPTION
Release artifacts were built without CGO_ENABLED, so on the ubuntu-latest runner the linux/amd64 binary was dynamically linked against glibc >= 2.34 via the net/os/user packages. Users on older glibc distros (Tencent Linux, CentOS 7/8) hit `GLIBC_2.34 not found` at runtime.

The codebase has zero cgo, so setting CGO_ENABLED=0 for all release targets is safe and produces fully static Linux binaries. Also mirror the setting in the Makefile's build-linux target so local builds match CI, and add a `file ... | grep statically linked` check to the release smoke test to prevent this regressing.