### PR TITLE
fix(release): remove direct COS uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,9 +81,6 @@ jobs:
           done
           (cd dist && shasum -a 256 * > checksums.txt)
           cp install.sh dist/install.sh
-          mkdir -p release_meta/latest
-          cp install.sh release_meta/latest/install.sh
-          printf 'v%s\n' "$VERSION" > release_meta/latest/VERSION
 
       - name: Install smoke test
         env:
@@ -109,8 +106,6 @@ jobs:
             test -f "dist/${ARTIFACT}"
             grep -q "  ${ARTIFACT}$" dist/checksums.txt
           done
-          test -f release_meta/latest/install.sh
-          test -f release_meta/latest/VERSION
 
       - name: Create GitHub Release and upload artifacts
         uses: softprops/action-gh-release@v2
@@ -120,25 +115,3 @@ jobs:
           body_path: RELEASE_NOTES.md
           files: |
             dist/*
-
-      - name: Upload version artifacts to Tencent Cloud COS
-        uses: TencentCloud/cos-action@v1
-        with:
-          secret_id: ${{ secrets.COS_RELEASE_SECRET_ID }}
-          secret_key: ${{ secrets.COS_RELEASE_SECRET_KEY }}
-          cos_bucket: ${{ secrets.COS_RELEASE_BUCKET }}
-          cos_region: ${{ secrets.COS_RELEASE_REGION }}
-          local_path: dist
-          remote_path: agr-cli/${{ steps.version.outputs.tag }}
-          clean: false
-
-      - name: Upload latest installer to Tencent Cloud COS
-        uses: TencentCloud/cos-action@v1
-        with:
-          secret_id: ${{ secrets.COS_RELEASE_SECRET_ID }}
-          secret_key: ${{ secrets.COS_RELEASE_SECRET_KEY }}
-          cos_bucket: ${{ secrets.COS_RELEASE_BUCKET }}
-          cos_region: ${{ secrets.COS_RELEASE_REGION }}
-          local_path: release_meta/latest
-          remote_path: agr-cli/latest
-          clean: false


### PR DESCRIPTION
## Summary

- Remove the direct Tencent Cloud COS upload steps from the release workflow.
- Remove the now-unused `release_meta/latest` staging and smoke-test assertions.
- Keep GitHub Release asset creation unchanged so the release webhook can synchronize published assets and latest metadata to COS.

## Why

The release webhook now owns COS synchronization after a GitHub release is published. Keeping the direct `TencentCloud/cos-action` steps in GitHub Actions duplicates that responsibility and can mark an otherwise successful release as failed, as reported in #56.

## Validation

- `make test` with live Tencent Cloud credentials unset (all local tests passed; credential-gated live suites skipped)
- Parsed `.github/workflows/release.yml` with Ruby YAML
- Confirmed the workflow no longer references `TencentCloud/cos-action`, `COS_RELEASE_*`, or `release_meta`
- `git diff --check`

Closes #56
