### PR TITLE
ci: add GitHub Actions workflow lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,8 +112,8 @@ jobs:
           tmpman="$(mktemp -d)"
           go run ./cmd/internal/docgen markdown --dir "$tmpdocs"
           go run ./cmd/internal/docgen man --dir "$tmpman"
-          test "$(ls -1 "$tmpdocs" | wc -l)" -gt 0
-          test "$(ls -1 "$tmpman" | wc -l)" -gt 0
+          test -n "$(find "$tmpdocs" -mindepth 1 -maxdepth 1 -type f -print -quit)"
+          test -n "$(find "$tmpman" -mindepth 1 -maxdepth 1 -type f -print -quit)"
 
   overlay-smoke:
     name: CLI Overlay Smoke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,17 @@ permissions:
   contents: read
 
 jobs:
+  workflow-lint:
+    name: Workflow Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check workflow files
+        uses: docker://rhysd/actionlint:1.7.12
+        with:
+          args: -color
+
   fmt:
     name: Format Check
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
             fi
             rm -rf "$work"
           done
-          (cd dist && shasum -a 256 * > checksums.txt)
+          (cd dist && shasum -a 256 -- * > checksums.txt)
           cp install.sh dist/install.sh
 
       - name: Install smoke test


### PR DESCRIPTION
## Summary

- add a dedicated `Workflow Lint` job to the existing CI workflow
- run the official actionlint Docker image pinned to version `1.7.12`
- validate every workflow on both `push` and `pull_request` with read-only repository permissions
- resolve the existing ShellCheck findings surfaced by the Docker image

## Why

The existing CI checks Go code, generated outputs, release readiness, and secrets, but it does not validate GitHub Actions syntax, expressions, job dependencies, or embedded scripts. Release-only workflow errors can therefore remain undetected until a tagged release.

The Docker image includes ShellCheck, which identified two `ls | wc -l` directory checks and one unguarded checksum glob. The directory checks now use `find`, and the checksum command uses `--` to terminate option parsing without changing manifest filenames.

## Validation

- actionlint v1.7.12 with ShellCheck v0.11.0
- docgen generated 52 Markdown files and 52 man pages; both new `find` checks passed
- `shasum -a 256 -- <files>`
- `go test ./cmd/... ./internal/... -count=1`
- `git diff --check`

Closes #58