### PR TITLE
ci: run unit tests on macOS in addition to Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,11 @@ jobs:
           fi
 
   test:
-    name: Unit Tests
-    runs-on: ubuntu-latest
+    name: Unit Tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v6
 

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 
 CLAUDE.md
 CODEBUDDY.md
+
+.history


### PR DESCRIPTION
Closes #63

## Summary

- Run the Unit Tests job on a matrix of `ubuntu-latest` and `macos-latest` so platform-specific regressions (e.g. darwin-only behavior around PTY, signal handling, path separators) are caught in CI rather than after release.
- Ignore the `.history` editor directory.

## Motivation

Unit tests currently only run on Linux (see #63). Since the CLI is also used on macOS, running the suite on macOS too gives earlier signal on platform-specific issues — directly addressing the darwin gap noted in the issue.

## Changes

- `.github/workflows/ci.yml`: convert the `test` job from a single `runs-on: ubuntu-latest` to a matrix over `os: [ubuntu-latest, macos-latest]`, and update the job name to `Unit Tests (${{ matrix.os }})`.
- `.gitignore`: add `.history`.

## Notes

- Rebased on latest `main` so the diff is limited to these two files; the existing `workflow-lint` job and shellcheck fixes are preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)