### PR TITLE
fix(tests): wait for paused state before resume

### DIFF
--- a/tests/instance/lifecycle/lifecycle_test.go
+++ b/tests/instance/lifecycle/lifecycle_test.go
@@ -65,6 +65,7 @@ var _ = Describe("instance lifecycle commands", Ordered, func() {
 		result := cli.Run(context.Background(), "--output", "json", "instance", "pause", instanceID)
 		result.ExpectSuccess()
 		Expect(result.Envelope().Command).To(Equal("instance.pause"))
+		testutil.WaitForInstanceStatus(context.Background(), instanceID, "PAUSED")
 	})
 
 	It("executes agr instance resume", func() {


### PR DESCRIPTION
## Summary

- wait for the live lifecycle instance to reach `PAUSED` before calling resume
- keep the existing wait for `RUNNING` after resume

## Root cause

The pause API is asynchronous. The smoke test treated an accepted pause request as a completed transition and could call resume while the instance was still `PAUSING`.

## Impact

This removes the pause/resume race from the live lifecycle smoke and prevents transient instances from entering a failed terminal state during the test.

## Validation

- `GOCACHE=/private/tmp/ags-cli-gocache GOTMPDIR=/private/tmp/ags-cli-gotmp go test ./tests/instance/lifecycle -v -count=1` (7/7 passed)

Closes #65