### PR TITLE
feat(delete): add --dry-run and --yes flags for destructive commands

### DIFF
--- a/internal/commands/instance/delete/command.go
+++ b/internal/commands/instance/delete/command.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/apicli"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/cli"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/output"
 )
@@ -54,12 +55,27 @@ func Module() command.Module {
 	spec.Args = []command.ArgSpec{
 		{Name: "instance-id", Required: true, Repeatable: true, Description: "Sandbox instance ID."},
 	}
-	spec.Flags = append(spec.Flags, command.FlagSpec{
-		Name:     "ignore-not-found",
-		Usage:    "Treat a missing instance as a successful delete",
-		Type:     command.FlagBool,
-		Workflow: true,
-	})
+	spec.Flags = append(spec.Flags,
+		command.FlagSpec{
+			Name:     "ignore-not-found",
+			Usage:    "Treat a missing instance as a successful delete",
+			Type:     command.FlagBool,
+			Workflow: true,
+		},
+		command.FlagSpec{
+			Name:     "dry-run",
+			Usage:    "List resources that would be deleted without actually executing the deletion",
+			Type:     command.FlagBool,
+			Workflow: true,
+		},
+		command.FlagSpec{
+			Name:      "yes",
+			Shorthand: "y",
+			Usage:     "Skip confirmation prompt",
+			Type:      command.FlagBool,
+			Workflow:  true,
+		},
+	)
 	spec.Output = command.OutputSpec{
 		DataType:    "DeleteData",
 		Description: "Delete result with workflow-level handling.",
@@ -87,6 +103,11 @@ func Module() command.Module {
 			builder := apicli.NewRequestBuilder(api)
 			return command.Runtime{
 				Handler: command.HandlerFunc(func(ctx context.Context, req command.Request) (*command.Result, error) {
+					dryRun := isDryRun(req)
+					skipConfirm := isYes(req)
+
+					// Collect instance IDs to delete.
+					var ids []string
 					if requestFlag(req) {
 						if len(req.Args) > 1 {
 							return nil, output.NewUsageError("REQUEST_FLAG_CONFLICT", "--request only supports a single instance id", "Use --request for one InstanceId at a time, or pass multiple positional arguments without --request.")
@@ -99,16 +120,36 @@ func Module() command.Module {
 						if strings.TrimSpace(instanceID) == "" {
 							return nil, output.NewUsageError("MISSING_REQUIRED_ARG", "missing instance id", "Provide <instance-id>.")
 						}
-						summary, warnings, err := deleteOne(ctx, cp, deps.ControlPlane, instanceID, ignoreNotFound(req))
-						if err != nil {
-							return nil, err
-						}
-						return resultFromSummary(summary, warnings, deps.IO.ErrOut), nil
+						ids = []string{instanceID}
+					} else {
+						ids = req.Args
 					}
 
+					// --dry-run: preview only, no actual deletion.
+					if dryRun {
+						return dryRunResult(ids, deps.IO.ErrOut), nil
+					}
+
+					// Confirmation prompt (unless --yes, --non-interactive, or non-TTY stdin).
+					if !skipConfirm && !cli.NonInteractive() && deps.IO != nil && deps.IO.IsStdinTTY() {
+						fmt.Fprintf(deps.IO.ErrOut, "The following instances will be deleted:\n")
+						for _, id := range ids {
+							fmt.Fprintf(deps.IO.ErrOut, "  - %s\n", id)
+						}
+						fmt.Fprintf(deps.IO.ErrOut, "\nProceed? [y/N] ")
+						var answer string
+						if _, err := fmt.Fscanln(deps.IO.In, &answer); err != nil || (answer != "y" && answer != "Y") {
+							return &command.Result{
+								Data: map[string]any{"Cancelled": true},
+								Text: func(w io.Writer) { fmt.Fprintln(w, "Cancelled.") },
+							}, nil
+						}
+					}
+
+					// Execute deletion.
 					summary := Summary{}
 					var warnings []string
-					for _, instanceID := range req.Args {
+					for _, instanceID := range ids {
 						item, itemWarnings, err := deleteOne(ctx, cp, deps.ControlPlane, instanceID, ignoreNotFound(req))
 						warnings = append(warnings, itemWarnings...)
 						if err != nil {
@@ -174,6 +215,32 @@ func requestFlag(req command.Request) bool {
 func ignoreNotFound(req command.Request) bool {
 	flag, ok := req.Flags["ignore-not-found"]
 	return ok && flag.Changed && flag.Bool
+}
+
+func isDryRun(req command.Request) bool {
+	flag, ok := req.Flags["dry-run"]
+	return ok && flag.Changed && flag.Bool
+}
+
+func isYes(req command.Request) bool {
+	flag, ok := req.Flags["yes"]
+	return ok && flag.Changed && flag.Bool
+}
+
+func dryRunResult(ids []string, errOut io.Writer) *command.Result {
+	return &command.Result{
+		Data: map[string]any{
+			"DryRun":      true,
+			"WouldDelete": ids,
+		},
+		Text: func(w io.Writer) {
+			fmt.Fprintln(w, "Dry run — the following instances would be deleted:")
+			for _, id := range ids {
+				fmt.Fprintf(w, "  - %s\n", id)
+			}
+			fmt.Fprintln(w, "\nNo changes were made.")
+		},
+	}
 }
 
 func isNotFound(classifier any, err error) bool {

--- a/internal/commands/instance/delete/command_test.go
+++ b/internal/commands/instance/delete/command_test.go
@@ -220,3 +220,61 @@ func (f *fakeControlPlane) IsNotFound(err error) bool {
 	var cliErr *output.CLIError
 	return errors.As(err, &cliErr) && cliErr.Failure != nil && cliErr.Failure.Kind == output.KindNotFound
 }
+
+func TestModuleDryRunDoesNotDelete(t *testing.T) {
+	cp := &fakeControlPlane{}
+	runtime, err := Module().Build(command.Deps{ControlPlane: cp})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	result, err := runtime.Handler.Run(context.Background(), command.Request{
+		Args: []string{"ins-a", "ins-b"},
+		Flags: map[string]command.FlagValue{
+			"dry-run":          {Name: "dry-run", Type: command.FlagBool, Bool: true, Changed: true},
+			"ignore-not-found": {Name: "ignore-not-found", Type: command.FlagBool},
+			"request":          {Name: "request", Type: command.FlagString},
+		},
+		ArgValues: map[string]string{"instance-id": "ins-a"},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(cp.deleted) != 0 {
+		t.Fatalf("dry-run should not delete, got deleted = %#v", cp.deleted)
+	}
+	data := result.Data.(map[string]any)
+	if data["DryRun"] != true {
+		t.Fatalf("expected DryRun=true, got %#v", data)
+	}
+	wouldDelete := data["WouldDelete"].([]string)
+	if len(wouldDelete) != 2 || wouldDelete[0] != "ins-a" || wouldDelete[1] != "ins-b" {
+		t.Fatalf("WouldDelete = %#v", wouldDelete)
+	}
+}
+
+func TestModuleYesSkipsConfirmation(t *testing.T) {
+	cp := &fakeControlPlane{}
+	runtime, err := Module().Build(command.Deps{ControlPlane: cp})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	result, err := runtime.Handler.Run(context.Background(), command.Request{
+		Args: []string{"ins-a"},
+		Flags: map[string]command.FlagValue{
+			"yes":              {Name: "yes", Type: command.FlagBool, Bool: true, Changed: true},
+			"ignore-not-found": {Name: "ignore-not-found", Type: command.FlagBool},
+			"request":          {Name: "request", Type: command.FlagString},
+		},
+		ArgValues: map[string]string{"instance-id": "ins-a"},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(cp.deleted) != 1 || cp.deleted[0] != "ins-a" {
+		t.Fatalf("expected deletion with --yes, got deleted = %#v", cp.deleted)
+	}
+	summary := result.Data.(map[string]any)
+	if summary["Deleted"] != 1 {
+		t.Fatalf("summary = %#v", summary)
+	}
+}

--- a/internal/commands/tool/delete/command.go
+++ b/internal/commands/tool/delete/command.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/apicli"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/cli"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/output"
 )
@@ -43,6 +44,21 @@ func Module() command.Module {
 	spec.Args = []command.ArgSpec{
 		{Name: "tool-id", Required: true, Repeatable: true, Description: "Sandbox tool ID."},
 	}
+	spec.Flags = append(spec.Flags,
+		command.FlagSpec{
+			Name:     "dry-run",
+			Usage:    "List resources that would be deleted without actually executing the deletion",
+			Type:     command.FlagBool,
+			Workflow: true,
+		},
+		command.FlagSpec{
+			Name:      "yes",
+			Shorthand: "y",
+			Usage:     "Skip confirmation prompt",
+			Type:      command.FlagBool,
+			Workflow:  true,
+		},
+	)
 	spec.Output = command.OutputSpec{
 		DataType:    "DeleteData",
 		Description: "Delete result with multi-tool handling.",
@@ -70,6 +86,10 @@ func Module() command.Module {
 			builder := apicli.NewRequestBuilder(api)
 			return command.Runtime{
 				Handler: command.HandlerFunc(func(ctx context.Context, req command.Request) (*command.Result, error) {
+					dryRun := isDryRun(req)
+					skipConfirm := isYes(req)
+
+					// --request mode: single tool, error propagates directly.
 					if requestFlag(req) {
 						if len(req.Args) > 1 {
 							return nil, output.NewUsageError("REQUEST_FLAG_CONFLICT", "--request only supports a single tool id", "Use --request for one ToolId at a time, or pass multiple positional arguments without --request.")
@@ -82,15 +102,42 @@ func Module() command.Module {
 						if strings.TrimSpace(toolID) == "" {
 							return nil, output.NewUsageError("MISSING_REQUIRED_ARG", "missing tool id", "Provide <tool-id>.")
 						}
+						if dryRun {
+							return dryRunResult([]string{toolID}, deps.IO.ErrOut), nil
+						}
 						if err := cp.DeleteTool(ctx, toolID); err != nil {
 							return nil, err
 						}
 						return resultFromSummary(Summary{Deleted: 1, DeletedIDs: []string{toolID}}, nil, deps.IO.ErrOut), nil
 					}
 
+					ids := req.Args
+
+					// --dry-run: preview only, no actual deletion.
+					if dryRun {
+						return dryRunResult(ids, deps.IO.ErrOut), nil
+					}
+
+					// Confirmation prompt (unless --yes, --non-interactive, or non-TTY stdin).
+					if !skipConfirm && !cli.NonInteractive() && deps.IO != nil && deps.IO.IsStdinTTY() {
+						fmt.Fprintf(deps.IO.ErrOut, "The following tools will be deleted:\n")
+						for _, id := range ids {
+							fmt.Fprintf(deps.IO.ErrOut, "  - %s\n", id)
+						}
+						fmt.Fprintf(deps.IO.ErrOut, "\nProceed? [y/N] ")
+						var answer string
+						if _, err := fmt.Fscanln(deps.IO.In, &answer); err != nil || (answer != "y" && answer != "Y") {
+							return &command.Result{
+								Data: map[string]any{"Cancelled": true},
+								Text: func(w io.Writer) { fmt.Fprintln(w, "Cancelled.") },
+							}, nil
+						}
+					}
+
+					// Execute deletion.
 					summary := Summary{}
 					var warnings []string
-					for _, toolID := range req.Args {
+					for _, toolID := range ids {
 						if err := cp.DeleteTool(ctx, toolID); err != nil {
 							summary.Failed++
 							summary.FailedIDs = append(summary.FailedIDs, toolID)
@@ -135,4 +182,30 @@ func resultFromSummary(summary Summary, warnings []string, errOut io.Writer) *co
 func requestFlag(req command.Request) bool {
 	flag, ok := req.Flags["request"]
 	return ok && flag.Changed && strings.TrimSpace(flag.String) != ""
+}
+
+func isDryRun(req command.Request) bool {
+	flag, ok := req.Flags["dry-run"]
+	return ok && flag.Changed && flag.Bool
+}
+
+func isYes(req command.Request) bool {
+	flag, ok := req.Flags["yes"]
+	return ok && flag.Changed && flag.Bool
+}
+
+func dryRunResult(ids []string, errOut io.Writer) *command.Result {
+	return &command.Result{
+		Data: map[string]any{
+			"DryRun":      true,
+			"WouldDelete": ids,
+		},
+		Text: func(w io.Writer) {
+			fmt.Fprintln(w, "Dry run — the following tools would be deleted:")
+			for _, id := range ids {
+				fmt.Fprintf(w, "  - %s\n", id)
+			}
+			fmt.Fprintln(w, "\nNo changes were made.")
+		},
+	}
 }

--- a/internal/commands/tool/delete/command_test.go
+++ b/internal/commands/tool/delete/command_test.go
@@ -178,3 +178,58 @@ func TestResultFromSummaryWritesSuccessToStdoutAndWarningsToStderr(t *testing.T)
 		t.Fatalf("stderr = %q", got)
 	}
 }
+
+func TestModuleDryRunDoesNotDelete(t *testing.T) {
+	cp := &fakeControlPlane{}
+	runtime, err := Module().Build(command.Deps{ControlPlane: cp})
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+	result, err := runtime.Handler.Run(context.Background(), command.Request{
+		Args:      []string{"sdt-a", "sdt-b"},
+		ArgValues: map[string]string{"tool-id": "sdt-a"},
+		Flags: map[string]command.FlagValue{
+			"dry-run": {Name: "dry-run", Type: command.FlagBool, Bool: true, Changed: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	// No actual deletion should have occurred.
+	if len(cp.deleted) != 0 {
+		t.Fatalf("dry-run should not delete, got deleted = %#v", cp.deleted)
+	}
+	data := result.Data.(map[string]any)
+	if data["DryRun"] != true {
+		t.Fatalf("expected DryRun=true, got %#v", data)
+	}
+	wouldDelete := data["WouldDelete"].([]string)
+	if len(wouldDelete) != 2 || wouldDelete[0] != "sdt-a" || wouldDelete[1] != "sdt-b" {
+		t.Fatalf("WouldDelete = %#v", wouldDelete)
+	}
+}
+
+func TestModuleYesSkipsConfirmation(t *testing.T) {
+	cp := &fakeControlPlane{}
+	runtime, err := Module().Build(command.Deps{ControlPlane: cp})
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+	result, err := runtime.Handler.Run(context.Background(), command.Request{
+		Args:      []string{"sdt-a"},
+		ArgValues: map[string]string{"tool-id": "sdt-a"},
+		Flags: map[string]command.FlagValue{
+			"yes": {Name: "yes", Type: command.FlagBool, Bool: true, Changed: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if len(cp.deleted) != 1 || cp.deleted[0] != "sdt-a" {
+		t.Fatalf("expected deletion with --yes, got deleted = %#v", cp.deleted)
+	}
+	summary := result.Data.(map[string]any)
+	if summary["Deleted"] != 1 {
+		t.Fatalf("summary = %#v", summary)
+	}
+}


### PR DESCRIPTION
## Summary

Add safety flags for `instance delete` and `tool delete` commands:

- `--dry-run`: Preview resources that would be deleted without actually executing the deletion
- `--yes` / `-y`: Skip interactive confirmation prompt

## Behavior

| Mode | What happens |
|------|-------------|
| `--dry-run` | Lists resources, exits without deleting |
| `--yes` | Skips confirmation, executes immediately |
| `--non-interactive` | Skips confirmation (global flag) |
| Non-TTY stdin | Skips confirmation (CI/pipeline compatible) |
| Interactive TTY (default) | Shows resource list + `Proceed? [y/N]` prompt |

## Examples

```bash
# Preview (no actual deletion)
agr instance delete sandbox-abc --dry-run

# Skip confirmation
agr instance delete sandbox-abc --yes
agr tool delete sdt-xxx -y

# Interactive confirmation (TTY only)
agr instance delete sandbox-abc sandbox-def
#   The following instances will be deleted:
#     - sandbox-abc
#     - sandbox-def
#   Proceed? [y/N]
```

## Testing

- Added unit tests for `--dry-run` (verifies no deletion occurs, returns preview data)
- Added unit tests for `--yes` (verifies confirmation is skipped)
- All existing tests pass (backward compatible)

Closes #62