### PR TITLE
chore(release): prepare v0.6.3

### DIFF
--- a/CHANGELOG-zh.md
+++ b/CHANGELOG-zh.md
@@ -2,6 +2,25 @@
 
 本项目的所有重要更改都将记录在此文件中。
 
+## [0.6.3] - 2026-07-15
+
+### 破坏性变更
+- 本版本没有破坏性变更。
+
+### 新功能
+- 为 `agr instance delete` 和 `agr tool delete` 增加删除保护：交互式终端现在会先列出目标资源并请求确认，新增 `--dry-run` 预览删除内容，以及 `--yes`/`-y` 跳过确认；现有非交互流程仍无需确认。
+- 支持通过 `brew install TencentCloudAgentRuntime/tap/agr-cli` 使用官方 Homebrew Tap，正式版本发布后会自动触发 Formula 校验和更新。
+- 强化 CI：增加 GitHub Actions workflow lint、聚合 `CI Gate`，并在 Linux 和 macOS 上运行单元测试。
+
+### Bug 修复
+- 构建完全静态链接的 Linux release 二进制，避免在 Tencent Linux、CentOS 7/8 等较旧发行版上出现 `GLIBC_2.34 not found`。
+- 移除 release 流水线中重复的 COS 直传步骤，统一由 GitHub release webhook 同步 COS，避免 GitHub Release 已成功但后续重复上传失败导致流水线整体报错。
+- 在 live 生命周期测试中等待实例真正进入 `PAUSED` 后再执行恢复，消除 pause/resume 竞态。
+
+### 文档
+- 在 README 和 README-zh 中补充官方 Homebrew Tap 安装命令。
+- 在中英文贡献指南中说明 `CI Gate` 和 `gitleaks` 是必需状态检查。
+
 ## [0.6.2] - 2026-06-12
 
 ### 破坏性变更

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.3] - 2026-07-15
+
+### Breaking Changes
+- This release has no Breaking Changes.
+
+### Features
+- Add deletion safeguards to `agr instance delete` and `agr tool delete`:
+  interactive terminals now show the target resources and request confirmation,
+  `--dry-run` previews deletions, and `--yes`/`-y` skips confirmation. Existing
+  non-interactive workflows continue without prompts.
+- Add official Homebrew Tap support through
+  `brew install TencentCloudAgentRuntime/tap/agr-cli`, with stable releases
+  automatically triggering Formula validation and updates.
+- Strengthen CI with GitHub Actions workflow linting, an aggregate `CI Gate`,
+  and unit tests on both Linux and macOS.
+
+### Bug Fixes
+- Build fully static Linux release binaries to prevent `GLIBC_2.34 not found`
+  failures on older distributions such as Tencent Linux and CentOS 7/8.
+- Remove duplicate direct COS uploads from the release workflow and leave COS
+  synchronization to the GitHub release webhook, preventing a successful
+  GitHub Release from being reported as failed by a later duplicate upload.
+- Wait for live lifecycle instances to reach `PAUSED` before resuming them,
+  removing a pause/resume race from the lifecycle smoke tests.
+
+### Docs
+- Document the official Homebrew Tap installation command in README and
+  README-zh.
+- Document `CI Gate` and `gitleaks` as the required status checks in both
+  contribution guides.
+
 ## [0.6.2] - 2026-06-12
 
 ### Breaking Changes


### PR DESCRIPTION
## Summary

- add matching `0.6.3` entries to `CHANGELOG.md` and `CHANGELOG-zh.md`
- cover all changes merged after `v0.6.2`, including delete safeguards, official Homebrew Tap support, static Linux release binaries, and CI/release reliability improvements
- keep the required release-note sections and ordering used by the tag-triggered release workflow

## Release highlights

- add `--dry-run`, `--yes`/`-y`, and interactive confirmation to `instance delete` and `tool delete`
- publish and validate stable releases through the official Homebrew Tap
- build fully static Linux binaries for compatibility with older glibc distributions
- remove duplicate direct COS uploads and rely on the GitHub release webhook for synchronization
- add workflow linting, an aggregate `CI Gate`, macOS unit tests, and a lifecycle pause/resume race fix

## Validation

- `bash scripts/changelog.sh validate-pair 0.6.3`
- `bash scripts/changelog.sh validate-release-notes-pair 0.6.3`
- `bash scripts/changelog.sh extract 0.6.3 /private/tmp/agr-cli-v0.6.3-release-notes.md`
- `go run ./cmd/internal/cobragen check`
- `go test ./internal/apimeta/... -count=1`
- `go test ./...`
- `git diff --check`

After this PR is merged, tag its merge commit as `v0.6.3` to trigger the release workflow.
