### PR TITLE
feat: unified error classifier with inline fix suggestions

### DIFF
--- a/internal/cli/cmdutil.go
+++ b/internal/cli/cmdutil.go
@@ -158,6 +158,11 @@ func Wrap(commandID string, fn CmdFunc) func(*cobra.Command, []string) error {
 			return nil
 		}
 
+		// Ensure Fix field is populated for result-path failures too.
+		if result.Failure != nil {
+			client.AttachFix(result.Failure)
+		}
+
 		status := "succeeded"
 		if result.ExitCode == output.ExitPartialSuccess || (result.Failure != nil && result.Failure.Kind == output.KindPartialSuccess) {
 			status = "partial"

--- a/internal/cli/error_render_test.go
+++ b/internal/cli/error_render_test.go
@@ -41,7 +41,8 @@ var _ = Describe("error rendering", func() {
 				"Error: backend failed\n" +
 					"Code: InternalError.Backend\n" +
 					"RequestId: req-123\n" +
-					"Hint: Run 'agr doctor'.\n",
+					"Hint: Run 'agr doctor'.\n" +
+					"\n  → Use \"agr explain InternalError.Backend\" for fix suggestions.\n",
 			))
 		})
 
@@ -49,10 +50,12 @@ var _ = Describe("error rendering", func() {
 			var buf bytes.Buffer
 			writeFailureText(&buf, &output.Failure{
 				Code:    "INVALID_USAGE",
+				Kind:    output.KindUsage,
 				Message: "bad flag",
 				Hint:    "Run 'agr --help'.",
 			})
 
+			// Usage errors do not get the "agr explain" suggestion.
 			Expect(buf.String()).To(Equal(
 				"Error: bad flag\n" +
 					"Code: INVALID_USAGE\n" +
@@ -73,6 +76,7 @@ var _ = Describe("error rendering", func() {
 			var buf bytes.Buffer
 			writeFailureText(&buf, &output.Failure{
 				Code:      "RequestLimitExceeded",
+				Kind:      output.KindRateLimit,
 				Message:   "throttled",
 				Retryable: true,
 				Details:   map[string]any{"RequestId": "req-xyz"},
@@ -82,7 +86,8 @@ var _ = Describe("error rendering", func() {
 				"Error: throttled\n" +
 					"Code: RequestLimitExceeded\n" +
 					"RequestId: req-xyz\n" +
-					"Retryable: yes\n",
+					"Retryable: yes\n" +
+					"\n  → Use \"agr explain RequestLimitExceeded\" for fix suggestions.\n",
 			))
 		})
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/client"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/config"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/output"
 	"github.com/spf13/cobra"
@@ -275,7 +276,10 @@ func extractHelpTopics(args []string) []string {
 }
 
 func classifyCLIError(err error) *output.CLIError {
-	cliErr := output.ClassifyError(err)
+	cliErr := client.ClassifyError(err)
+	if cliErr == nil {
+		return output.ClassifyError(err)
+	}
 	if cliErr.ExitCode == output.ExitGenericError && isCobraUsageError(err) {
 		cliErr = output.NewUsageError("INVALID_USAGE", err.Error(), "Run 'agr --help' or 'agr schema -o json' to inspect valid commands and flags.")
 	}
@@ -352,8 +356,15 @@ func writeFailureText(w io.Writer, failure *output.Failure) {
 	if failure.Hint != "" {
 		fmt.Fprintf(w, "Hint: %s\n", failure.Hint)
 	}
+	if failure.Fix != "" {
+		fmt.Fprintf(w, "Fix: %s\n", failure.Fix)
+	}
 	if failure.Retryable {
 		fmt.Fprintln(w, "Retryable: yes")
+	}
+	// Auto-suggest "agr explain" for non-usage errors with a known code.
+	if failure.Code != "" && failure.Kind != output.KindUsage {
+		fmt.Fprintf(w, "\n  → Use \"agr explain %s\" for fix suggestions.\n", failure.Code)
 	}
 }
 

--- a/internal/client/classify.go
+++ b/internal/client/classify.go
@@ -1,0 +1,72 @@
+package client
+
+import (
+	"errors"
+
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/output"
+	sdkerrors "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
+)
+
+// ClassifyError is the unified error classification entry point. It tries
+// cloud SDK error classification first (most specific), then falls back to
+// the generic Go error classifier. All command-layer error returns should
+// go through this function for consistent user-facing output.
+//
+// Classification priority:
+//  1. Already a *output.CLIError → return as-is
+//  2. TencentCloud SDK error → ClassifyCloudError (kind/code/hint from API response)
+//  3. Generic Go error → output.ClassifyError (timeout/network/canceled/internal)
+func ClassifyError(err error) *output.CLIError {
+	if err == nil {
+		return nil
+	}
+
+	// If already classified, return directly.
+	if cliErr, ok := err.(*output.CLIError); ok {
+		return attachFix(cliErr)
+	}
+
+	// Check if it's a TencentCloud SDK error using errors.As (safe for
+	// uncomparable error types that would panic with == comparison).
+	var sdkErr *sdkerrors.TencentCloudSDKError
+	if errors.As(err, &sdkErr) {
+		classified := ClassifyCloudError(err)
+		if cliErr, ok := classified.(*output.CLIError); ok {
+			return attachFix(cliErr)
+		}
+	}
+
+	// Fall through to generic Go error classification.
+	return attachFix(output.ClassifyError(err))
+}
+
+// attachFix applies Fix to a CLIError wrapper.
+func attachFix(cliErr *output.CLIError) *output.CLIError {
+	if cliErr == nil || cliErr.Failure == nil {
+		return cliErr
+	}
+	AttachFix(cliErr.Failure)
+	return cliErr
+}
+
+// AttachFix populates the Failure.Fix field with an actionable command based
+// on the error kind. Exported so that non-error result paths (e.g.
+// CmdResult{Failure: ...}) can also apply Fix consistently.
+func AttachFix(failure *output.Failure) *output.Failure {
+	if failure == nil || failure.Fix != "" {
+		return failure
+	}
+	switch failure.Kind {
+	case output.KindNotFound:
+		failure.Fix = "agr instance list / agr tool list"
+	case output.KindAuthOrPermission:
+		failure.Fix = "agr init / agr doctor"
+	case output.KindNetwork:
+		failure.Fix = "agr doctor"
+	case output.KindTimeout:
+		failure.Fix = "retry with longer --timeout or check agr doctor"
+	case output.KindRateLimit:
+		failure.Fix = "wait and retry"
+	}
+	return failure
+}

--- a/internal/client/classify_test.go
+++ b/internal/client/classify_test.go
@@ -1,0 +1,233 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/output"
+	sdkerrors "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
+)
+
+func TestClassifyErrorNil(t *testing.T) {
+	result := ClassifyError(nil)
+	if result != nil {
+		t.Fatalf("expected nil, got %+v", result)
+	}
+}
+
+func TestClassifyErrorAlreadyCLIError(t *testing.T) {
+	original := output.NewNotFoundError("TEST_NOT_FOUND", "not found", "hint")
+	result := ClassifyError(original)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.Failure.Code != "TEST_NOT_FOUND" {
+		t.Fatalf("Code = %q, want TEST_NOT_FOUND", result.Failure.Code)
+	}
+	if result.Failure.Fix == "" {
+		t.Fatal("expected Fix to be populated for not_found kind")
+	}
+}
+
+func TestClassifyErrorSDKNotFound(t *testing.T) {
+	sdkErr := sdkerrors.NewTencentCloudSDKError("ResourceNotFound.SandboxInstance", "instance not found", "req-123")
+	result := ClassifyError(sdkErr)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.Failure.Kind != output.KindNotFound {
+		t.Fatalf("Kind = %q, want not_found", result.Failure.Kind)
+	}
+	if result.Failure.Code != "ResourceNotFound.SandboxInstance" {
+		t.Fatalf("Code = %q", result.Failure.Code)
+	}
+	if result.Failure.Fix == "" {
+		t.Fatal("expected Fix to be populated")
+	}
+}
+
+func TestClassifyErrorSDKAuth(t *testing.T) {
+	sdkErr := sdkerrors.NewTencentCloudSDKError("AuthFailure.SecretIdNotFound", "id not found", "req-456")
+	result := ClassifyError(sdkErr)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.Failure.Kind != output.KindAuthOrPermission {
+		t.Fatalf("Kind = %q, want auth", result.Failure.Kind)
+	}
+	if result.Failure.Fix == "" {
+		t.Fatal("expected Fix to be populated for auth kind")
+	}
+}
+
+func TestClassifyErrorSDKRateLimit(t *testing.T) {
+	sdkErr := sdkerrors.NewTencentCloudSDKError("RequestLimitExceeded", "too many requests", "req-789")
+	result := ClassifyError(sdkErr)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.Failure.Kind != output.KindRateLimit {
+		t.Fatalf("Kind = %q, want rate_limit", result.Failure.Kind)
+	}
+	if !result.Failure.Retryable {
+		t.Fatal("expected Retryable=true")
+	}
+	if result.Failure.Fix != "wait and retry" {
+		t.Fatalf("Fix = %q, want 'wait and retry'", result.Failure.Fix)
+	}
+}
+
+func TestClassifyErrorTimeout(t *testing.T) {
+	result := ClassifyError(context.DeadlineExceeded)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.Failure.Kind != output.KindTimeout {
+		t.Fatalf("Kind = %q, want timeout", result.Failure.Kind)
+	}
+	if result.Failure.Fix == "" {
+		t.Fatal("expected Fix to be populated for timeout kind")
+	}
+}
+
+func TestClassifyErrorNetwork(t *testing.T) {
+	netErr := &net.DNSError{Err: "no such host", Name: "example.com"}
+	result := ClassifyError(netErr)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.Failure.Kind != output.KindNetwork {
+		t.Fatalf("Kind = %q, want network", result.Failure.Kind)
+	}
+	if result.Failure.Fix != "agr doctor" {
+		t.Fatalf("Fix = %q, want 'agr doctor'", result.Failure.Fix)
+	}
+}
+
+func TestClassifyErrorGeneric(t *testing.T) {
+	result := ClassifyError(errors.New("something unexpected"))
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.Failure.Kind != output.KindGenericError {
+		t.Fatalf("Kind = %q, want error", result.Failure.Kind)
+	}
+	// Generic errors don't get a Fix.
+	if result.Failure.Fix != "" {
+		t.Fatalf("Fix = %q, want empty for generic error", result.Failure.Fix)
+	}
+}
+
+func TestClassifyErrorPreservesExistingFix(t *testing.T) {
+	original := &output.CLIError{
+		Failure: &output.Failure{
+			Code: "CUSTOM",
+			Kind: output.KindNotFound,
+			Fix:  "custom fix already set",
+		},
+		ExitCode: 1,
+	}
+	result := ClassifyError(original)
+	if result.Failure.Fix != "custom fix already set" {
+		t.Fatalf("Fix = %q, expected existing fix to be preserved", result.Failure.Fix)
+	}
+}
+
+func TestAttachFixNotFound(t *testing.T) {
+	cliErr := &output.CLIError{Failure: &output.Failure{Kind: output.KindNotFound}}
+	result := attachFix(cliErr)
+	if result.Failure.Fix != "agr instance list / agr tool list" {
+		t.Fatalf("Fix = %q", result.Failure.Fix)
+	}
+}
+
+func TestAttachFixAuth(t *testing.T) {
+	cliErr := &output.CLIError{Failure: &output.Failure{Kind: output.KindAuthOrPermission}}
+	result := attachFix(cliErr)
+	if result.Failure.Fix != "agr init / agr doctor" {
+		t.Fatalf("Fix = %q", result.Failure.Fix)
+	}
+}
+
+func TestAttachFixNetwork(t *testing.T) {
+	cliErr := &output.CLIError{Failure: &output.Failure{Kind: output.KindNetwork}}
+	result := attachFix(cliErr)
+	if result.Failure.Fix != "agr doctor" {
+		t.Fatalf("Fix = %q", result.Failure.Fix)
+	}
+}
+
+func TestAttachFixTimeout(t *testing.T) {
+	cliErr := &output.CLIError{Failure: &output.Failure{Kind: output.KindTimeout}}
+	result := attachFix(cliErr)
+	if result.Failure.Fix != "retry with longer --timeout or check agr doctor" {
+		t.Fatalf("Fix = %q", result.Failure.Fix)
+	}
+}
+
+func TestAttachFixRateLimit(t *testing.T) {
+	cliErr := &output.CLIError{Failure: &output.Failure{Kind: output.KindRateLimit}}
+	result := attachFix(cliErr)
+	if result.Failure.Fix != "wait and retry" {
+		t.Fatalf("Fix = %q", result.Failure.Fix)
+	}
+}
+
+func TestAttachFixUsageNoFix(t *testing.T) {
+	cliErr := &output.CLIError{Failure: &output.Failure{Kind: output.KindUsage}}
+	result := attachFix(cliErr)
+	if result.Failure.Fix != "" {
+		t.Fatalf("Fix = %q, want empty for usage kind", result.Failure.Fix)
+	}
+}
+
+func TestAttachFixNilSafe(t *testing.T) {
+	if attachFix(nil) != nil {
+		t.Fatal("expected nil")
+	}
+	if attachFix(&output.CLIError{}) != nil {
+		// Failure is nil → should not panic.
+		t.Log("non-nil CLIError with nil Failure handled")
+	}
+}
+
+// sliceError contains a slice field, making it uncomparable with ==.
+type sliceError struct{ values []string }
+
+func (e sliceError) Error() string { return "slice error" }
+
+func TestClassifyErrorDoesNotPanicOnUncomparableError(t *testing.T) {
+	// Regression: using == to compare error interfaces panics if the
+	// underlying type contains slices/maps. ClassifyError must handle this.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("ClassifyError panicked: %v", r)
+		}
+	}()
+	result := ClassifyError(sliceError{values: []string{"x"}})
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.Failure.Kind != output.KindGenericError {
+		t.Fatalf("Kind = %q, want error", result.Failure.Kind)
+	}
+}
+
+func TestAttachFixExported(t *testing.T) {
+	// Verify the exported AttachFix works on bare Failure (for CmdResult path).
+	f := &output.Failure{Kind: output.KindNotFound}
+	AttachFix(f)
+	if f.Fix != "agr instance list / agr tool list" {
+		t.Fatalf("Fix = %q", f.Fix)
+	}
+}
+
+func TestAttachFixExportedPreservesExisting(t *testing.T) {
+	f := &output.Failure{Kind: output.KindNotFound, Fix: "custom"}
+	AttachFix(f)
+	if f.Fix != "custom" {
+		t.Fatalf("Fix = %q, expected preserved 'custom'", f.Fix)
+	}
+}

--- a/internal/output/envelope.go
+++ b/internal/output/envelope.go
@@ -18,6 +18,7 @@ type Failure struct {
 	Kind      string         `json:"Kind"`
 	Message   string         `json:"Message"`
 	Hint      string         `json:"Hint,omitempty"`
+	Fix       string         `json:"Fix,omitempty"`
 	Retryable bool           `json:"Retryable"`
 	Details   map[string]any `json:"Details,omitempty"`
 }

--- a/tests/root/error_classifier_test.go
+++ b/tests/root/error_classifier_test.go
@@ -1,0 +1,101 @@
+// Package root_test contains credential-free smoke tests for the unified error
+// classifier. These tests run in any CI environment because they do not call
+// the remote API and do not require AGR_LIVE_TEST or cloud credentials.
+//
+// They use the standard go test framework (not Ginkgo) so they are not bound
+// to testutil.SetupSuite, which ginkgo.Skip()s the entire suite when
+// credentials are missing.
+package root_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os/exec"
+	"testing"
+)
+
+// errorClassifierTestBinary builds the agr binary into a temp dir.
+func errorClassifierTestBinary(t *testing.T) string {
+	t.Helper()
+	out, err := exec.Command("go", "env", "GOMOD").Output()
+	if err != nil {
+		t.Fatalf("go env GOMOD failed: %v", err)
+	}
+	mod := string(bytes.TrimSpace(out))
+	repoRoot := mod[:len(mod)-len("/go.mod")]
+
+	dir := t.TempDir()
+	bin := dir + "/agr"
+	// #nosec G204 -- test-only command with controlled args.
+	cmd := exec.Command("go", "build", "-o", bin, "./cmd/agr")
+	cmd.Dir = repoRoot
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build failed: %v\n%s", err, out)
+	}
+	return bin
+}
+
+func runAgr(t *testing.T, bin, home string, args ...string) (stdout, stderr string) {
+	t.Helper()
+	cmd := exec.Command(bin, args...) // #nosec G204 -- test-only.
+	cmd.Env = append([]string{"HOME=" + home, "PATH=/usr/bin:/bin"}, "")
+	var so, se bytes.Buffer
+	cmd.Stdout = &so
+	cmd.Stderr = &se
+	_ = cmd.Run()
+	return so.String(), se.String()
+}
+
+func TestErrorClassifierNoCredentials(t *testing.T) {
+	bin := errorClassifierTestBinary(t)
+	home := t.TempDir()
+
+	t.Run("FixAndExplainShownForRealError", func(t *testing.T) {
+		// Use a resource that doesn't exist. The error path may be:
+		//  - not_found (resource missing in cloud) → Fix + explain
+		//  - auth (no credentials) → Fix + explain
+		// Both should show Fix and agr explain in stderr.
+		_, stderr := runAgr(t, bin, home, "instance", "get", "ins-nonexistent-test-id-zzz")
+		if !bytes.Contains([]byte(stderr), []byte("Fix:")) {
+			t.Fatalf("expected 'Fix:' in stderr, got: %q", stderr)
+		}
+		if !bytes.Contains([]byte(stderr), []byte("agr explain")) {
+			t.Fatalf("expected 'agr explain' suggestion, got: %q", stderr)
+		}
+	})
+
+	t.Run("JSONFailureHasFixField", func(t *testing.T) {
+		stdout, _ := runAgr(t, bin, home, "--output", "json", "instance", "get", "ins-nonexistent-test-id-zzz")
+		var env struct {
+			Failure struct {
+				Code string `json:"Code"`
+				Kind string `json:"Kind"`
+				Fix  string `json:"Fix"`
+			} `json:"Failure"`
+		}
+		if err := json.Unmarshal([]byte(stdout), &env); err != nil {
+			t.Fatalf("invalid JSON envelope: %v\nstdout=%q", err, stdout)
+		}
+		if env.Failure.Code == "" {
+			t.Fatal("expected non-empty Code in JSON Failure")
+		}
+		// Fix should be populated for non-usage errors.
+		if env.Failure.Kind != "usage" && env.Failure.Fix == "" {
+			t.Fatalf("expected Fix to be set for kind=%q, got empty", env.Failure.Kind)
+		}
+	})
+
+	t.Run("UsageErrorDoesNotShowExplain", func(t *testing.T) {
+		_, stderr := runAgr(t, bin, home, "instance", "create")
+		if bytes.Contains([]byte(stderr), []byte("agr explain")) {
+			t.Fatalf("usage error should not show explain suggestion, got: %q", stderr)
+		}
+	})
+
+	t.Run("UnknownCommandDoesNotShowExplain", func(t *testing.T) {
+		_, stderr := runAgr(t, bin, home, "nonexistent-cmd-xyz")
+		if bytes.Contains([]byte(stderr), []byte("agr explain")) {
+			t.Fatalf("unknown command should not show explain, got: %q", stderr)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Implement a unified error classification entry point with automatic inline fix suggestions, inspired by AgentCore CLI's `FatalError` component with `suggestedCommand` pattern.

## Changes

| File | Change |
|------|--------|
| `internal/output/envelope.go` | Add `Fix` field to `Failure` struct |
| `internal/client/classify.go` | New unified `ClassifyError()` entry point |
| `internal/cli/root.go` | Use unified classifier + auto-append `agr explain` suggestion |
| `internal/cli/error_render_test.go` | Update test expectations |

## Before vs After

**Before:**
```
Error: instance not found: ins-notexist
Code: INSTANCE_NOT_FOUND
Hint: Run 'agr instance list' to find active instances.
```

**After:**
```
Error: instance not found: ins-notexist
Code: INSTANCE_NOT_FOUND
Hint: Run 'agr instance list' to find active instances.
Fix: agr instance list / agr tool list

  -> Use "agr explain INSTANCE_NOT_FOUND" for fix suggestions.
```

**Usage errors (no explain suggestion):**
```
Error: must specify either --tool-name/-t or --tool-id
Code: MISSING_REQUIRED_FLAG
Hint: Provide --tool-name for a named tool or --tool-id for a cloud tool ID.
```

## JSON Output

```json
{
  "Failure": {
    "Code": "INSTANCE_NOT_FOUND",
    "Kind": "not_found",
    "Message": "instance not found: ins-notexist",
    "Hint": "Run 'agr instance list' to find active instances.",
    "Fix": "agr instance list / agr tool list",
    "Retryable": false
  }
}
```

## Unified Classification Pipeline

```
err
 |-> Already *CLIError? -> return
 |-> TencentCloud SDK error? -> ClassifyCloudError (kind/code/hint)
 |-> Generic Go error? -> output.ClassifyError (timeout/network/etc)
 +-> attachFix() -> auto-populate Fix field by Kind
```

## Fix Field Mapping

| Kind | Fix |
|------|-----|
| not_found | agr instance list / agr tool list |
| auth | agr init / agr doctor |
| network | agr doctor |
| timeout | retry with longer --timeout or check agr doctor |
| rate_limit | wait and retry |
| usage | (no Fix, no explain suggestion) |

Closes #77