### PR TITLE
feat: add wait support for instance and tool

### DIFF
--- a/cmd/agr/characterization_test.go
+++ b/cmd/agr/characterization_test.go
@@ -671,6 +671,32 @@ func schemaForCommand(t *testing.T, command string) commandSchemaSnapshot {
 	return snapshot
 }
 
+func TestCharacterization_WaitFlagSchemaScope(t *testing.T) {
+	for _, commandID := range []string{
+		"instance.create",
+		"instance.get",
+		"instance.pause",
+		"instance.resume",
+		"instance.update",
+		"tool.create",
+		"tool.fork",
+		"tool.get",
+		"tool.update",
+	} {
+		schema := schemaForCommand(t, commandID)
+		flag, ok := schema.Flags["wait"]
+		if !ok || flag.Type != "bool" {
+			t.Errorf("schema %s wait flag = %#v, present = %v", commandID, flag, ok)
+		}
+	}
+	for _, commandID := range []string{"instance.delete", "instance.list", "tool.delete", "tool.list"} {
+		schema := schemaForCommand(t, commandID)
+		if flag, ok := schema.Flags["wait"]; ok {
+			t.Errorf("schema %s unexpectedly includes wait flag: %#v", commandID, flag)
+		}
+	}
+}
+
 func schemaSnapshotForCommand(t *testing.T, command string) commandSchemaSnapshot {
 	t.Helper()
 	output, err := runAGR(t, "schema", command, "-o", "json")

--- a/cmd/agr/characterization_test.go
+++ b/cmd/agr/characterization_test.go
@@ -674,11 +674,13 @@ func schemaForCommand(t *testing.T, command string) commandSchemaSnapshot {
 func TestCharacterization_WaitFlagSchemaScope(t *testing.T) {
 	for _, commandID := range []string{
 		"instance.create",
+		"instance.delete",
 		"instance.get",
 		"instance.pause",
 		"instance.resume",
 		"instance.update",
 		"tool.create",
+		"tool.delete",
 		"tool.fork",
 		"tool.get",
 		"tool.update",
@@ -689,7 +691,7 @@ func TestCharacterization_WaitFlagSchemaScope(t *testing.T) {
 			t.Errorf("schema %s wait flag = %#v, present = %v", commandID, flag, ok)
 		}
 	}
-	for _, commandID := range []string{"instance.delete", "instance.list", "tool.delete", "tool.list"} {
+	for _, commandID := range []string{"instance.list", "tool.list"} {
 		schema := schemaForCommand(t, commandID)
 		if flag, ok := schema.Flags["wait"]; ok {
 			t.Errorf("schema %s unexpectedly includes wait flag: %#v", commandID, flag)

--- a/internal/commands/instance/create/command.go
+++ b/internal/commands/instance/create/command.go
@@ -9,7 +9,9 @@ import (
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/apicli"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/cli"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
+	instanceget "github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/instance/get"
 	instanceview "github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/instance/internal/instanceview"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/internal/resourcewait"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/output"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/progress"
 	ags "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ags/v20250920"
@@ -19,6 +21,7 @@ import (
 func Module() command.Module {
 	api := APIDescriptor()
 	spec := api.CommandSpec()
+	spec.Flags = append(spec.Flags, resourcewait.Flag())
 	spec.Output = command.OutputSpec{
 		DataType:    "InstanceCreateData",
 		Description: "Instance create result with normalized instance data.",
@@ -77,10 +80,35 @@ func Module() command.Module {
 					})
 				}
 				sp.Stop("✓", "Instance created")
-				return instanceCreateResult(response, result), nil
+				mutationResult := instanceCreateResult(response, result)
+				if !resourcewait.Requested(req) {
+					return mutationResult, nil
+				}
+				getter, ok := deps.ControlPlane.(resourcewait.InstanceGetter)
+				if !ok {
+					return nil, fmt.Errorf("instance.create --wait requires GetInstance support")
+				}
+				instanceID := instanceview.DerefString(response.Instance.InstanceId)
+				if instanceID == "" {
+					return nil, missingInstanceIDError()
+				}
+				finalInstance, err := resourcewait.WaitForInstance(ctx, instanceID, getter.GetInstance, resourcewait.OptionsFromDeps(deps))
+				if err != nil {
+					return nil, err
+				}
+				return resourcewait.PreserveMutationMetadata(instanceget.Result(finalInstance), mutationResult), nil
 			})}, nil
 		},
 	}
+}
+
+func missingInstanceIDError() error {
+	return output.NewCLIError(&output.Failure{
+		Code:    "INTERNAL_ERROR",
+		Kind:    output.KindGenericError,
+		Message: "cannot wait because the create response did not include an instance id",
+		Hint:    "Rerun with --debug. If the issue persists, inspect the control-plane response.",
+	})
 }
 
 func validateToolSelection(req command.Request) error {

--- a/internal/commands/instance/create/command.go
+++ b/internal/commands/instance/create/command.go
@@ -92,7 +92,13 @@ func Module() command.Module {
 				if instanceID == "" {
 					return nil, missingInstanceIDError()
 				}
-				finalInstance, err := resourcewait.WaitForInstance(ctx, instanceID, getter.GetInstance, resourcewait.OptionsFromDeps(deps))
+				finalInstance, err := resourcewait.WaitForInstanceWithPolicy(
+					ctx,
+					instanceID,
+					getter.GetInstance,
+					resourcewait.InstancePolicy(resourcewait.OperationCreate),
+					resourcewait.OptionsFromDeps(deps),
+				)
 				if err != nil {
 					return nil, err
 				}

--- a/internal/commands/instance/create/command_test.go
+++ b/internal/commands/instance/create/command_test.go
@@ -6,8 +6,10 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/internal/resourcewait"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/iostreams"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/output"
 	ags "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ags/v20250920"
@@ -16,18 +18,27 @@ import (
 // fakeMixedControlPlane implements apicli.ControlPlane for testing the full
 // create flow (parameter validation → request build → executor → response render).
 type fakeMixedControlPlane struct {
-	action  string
-	request map[string]any
-	resp    *ags.StartSandboxInstanceResponseParams
+	action        string
+	request       map[string]any
+	resp          *ags.StartSandboxInstanceResponseParams
+	calls         int
+	getCalls      int
+	finalInstance *ags.SandboxInstance
 }
 
 func (f *fakeMixedControlPlane) Call(_ context.Context, action string, request map[string]any) (any, error) {
 	f.action = action
 	f.request = request
+	f.calls++
 	if f.resp != nil {
 		return f.resp, nil
 	}
 	return map[string]any{"ok": true}, nil
+}
+
+func (f *fakeMixedControlPlane) GetInstance(_ context.Context, _ string) (*ags.SandboxInstance, error) {
+	f.getCalls++
+	return f.finalInstance, nil
 }
 
 // allInstanceCreateFlags returns a complete flag set mimicking what Cobra registers
@@ -157,6 +168,34 @@ func TestModuleCreatesInstanceAndRendersText(t *testing.T) {
 	}
 	if !strings.Contains(text, "RUNNING") {
 		t.Fatalf("text output missing status: %s", text)
+	}
+}
+
+func TestModuleWaitsAfterCreatingExactlyOnce(t *testing.T) {
+	id := "ins-created"
+	starting := "STARTING"
+	running := "RUNNING"
+	cp := &fakeMixedControlPlane{
+		resp:          &ags.StartSandboxInstanceResponseParams{Instance: &ags.SandboxInstance{InstanceId: &id, Status: &starting}},
+		finalInstance: &ags.SandboxInstance{InstanceId: &id, Status: &running},
+	}
+	runtime, err := Module().Build(command.Deps{ControlPlane: cp, Values: map[string]any{
+		resourcewait.OptionsKey: resourcewait.Options{Interval: time.Millisecond, Timeout: 50 * time.Millisecond},
+	}})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	flags := withChanged(allInstanceCreateFlags(), "tool-name", "tool-name")
+	flags["wait"] = command.FlagValue{Name: "wait", Type: command.FlagBool, Bool: true}
+	result, err := runtime.Handler.Run(context.Background(), command.Request{Flags: flags})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if cp.calls != 1 || cp.getCalls != 1 {
+		t.Fatalf("Call = %d, GetInstance = %d", cp.calls, cp.getCalls)
+	}
+	if result.Data.(map[string]any)["Status"] != running || len(result.Effects) != 1 {
+		t.Fatalf("result = %#v", result)
 	}
 }
 

--- a/internal/commands/instance/create/command_test.go
+++ b/internal/commands/instance/create/command_test.go
@@ -199,6 +199,32 @@ func TestModuleWaitsAfterCreatingExactlyOnce(t *testing.T) {
 	}
 }
 
+func TestModuleWaitDoesNotTreatStoppedInstanceAsCreated(t *testing.T) {
+	id := "ins-created"
+	starting := "STARTING"
+	stopped := "STOPPED"
+	cp := &fakeMixedControlPlane{
+		resp:          &ags.StartSandboxInstanceResponseParams{Instance: &ags.SandboxInstance{InstanceId: &id, Status: &starting}},
+		finalInstance: &ags.SandboxInstance{InstanceId: &id, Status: &stopped},
+	}
+	runtime, err := Module().Build(command.Deps{ControlPlane: cp, Values: map[string]any{
+		resourcewait.OptionsKey: resourcewait.Options{Interval: time.Millisecond, Timeout: 50 * time.Millisecond},
+	}})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	flags := withChanged(allInstanceCreateFlags(), "tool-name", "tool-name")
+	flags["wait"] = command.FlagValue{Name: "wait", Type: command.FlagBool, Bool: true}
+	_, err = runtime.Handler.Run(context.Background(), command.Request{Flags: flags})
+	var cliErr *output.CLIError
+	if !errors.As(err, &cliErr) || cliErr.Failure.Code != "WAIT_PREEMPTED" {
+		t.Fatalf("error = %#v, want WAIT_PREEMPTED", err)
+	}
+	if cp.calls != 1 || cp.getCalls != 1 {
+		t.Fatalf("Call = %d, GetInstance = %d", cp.calls, cp.getCalls)
+	}
+}
+
 func TestModuleCreatesInstanceWithToolID(t *testing.T) {
 	id := "ins-byid"
 	toolID := "sdt-abc123"

--- a/internal/commands/instance/delete/command.go
+++ b/internal/commands/instance/delete/command.go
@@ -158,9 +158,9 @@ func Module() command.Module {
 							warnings = append(warnings, fmt.Sprintf("Failed to delete %s: %v", instanceID, err))
 							continue
 						}
+						summary.AlreadyAbsent = append(summary.AlreadyAbsent, item.AlreadyAbsent...)
 						summary.Deleted += item.Deleted
 						summary.DeletedIDs = append(summary.DeletedIDs, item.DeletedIDs...)
-						summary.AlreadyAbsent = append(summary.AlreadyAbsent, item.AlreadyAbsent...)
 					}
 					return resultFromSummary(summary, warnings, deps.IO.ErrOut), nil
 				}),

--- a/internal/commands/instance/delete/command.go
+++ b/internal/commands/instance/delete/command.go
@@ -9,6 +9,7 @@ import (
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/apicli"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/cli"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/internal/resourcewait"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/output"
 )
 
@@ -56,6 +57,7 @@ func Module() command.Module {
 		{Name: "instance-id", Required: true, Repeatable: true, Description: "Sandbox instance ID."},
 	}
 	spec.Flags = append(spec.Flags,
+		resourcewait.Flag(),
 		command.FlagSpec{
 			Name:     "ignore-not-found",
 			Usage:    "Treat a missing instance as a successful delete",
@@ -149,6 +151,17 @@ func Module() command.Module {
 					// Execute deletion.
 					summary := Summary{}
 					var warnings []string
+					waitRequested := resourcewait.Requested(req)
+					var getter resourcewait.InstanceGetter
+					if waitRequested {
+						var ok bool
+						getter, ok = deps.ControlPlane.(resourcewait.InstanceGetter)
+						if !ok {
+							return nil, fmt.Errorf("instance.delete --wait requires GetInstance support")
+						}
+					}
+
+					acceptedIDs := make([]string, 0, len(ids))
 					for _, instanceID := range ids {
 						item, itemWarnings, err := deleteOne(ctx, cp, deps.ControlPlane, instanceID, ignoreNotFound(req))
 						warnings = append(warnings, itemWarnings...)
@@ -159,8 +172,33 @@ func Module() command.Module {
 							continue
 						}
 						summary.AlreadyAbsent = append(summary.AlreadyAbsent, item.AlreadyAbsent...)
+						if item.Deleted > 0 && waitRequested {
+							acceptedIDs = append(acceptedIDs, instanceID)
+							continue
+						}
 						summary.Deleted += item.Deleted
 						summary.DeletedIDs = append(summary.DeletedIDs, item.DeletedIDs...)
+					}
+
+					if waitRequested {
+						options := resourcewait.OptionsFromDeps(deps)
+						for _, instanceID := range acceptedIDs {
+							_, err := resourcewait.WaitForInstanceWithPolicy(
+								ctx,
+								instanceID,
+								getter.GetInstance,
+								resourcewait.InstancePolicy(resourcewait.OperationDelete),
+								options,
+							)
+							if err != nil {
+								summary.Failed++
+								summary.FailedIDs = append(summary.FailedIDs, instanceID)
+								warnings = append(warnings, fmt.Sprintf("Failed waiting for %s to be deleted: %v", instanceID, err))
+								continue
+							}
+							summary.Deleted++
+							summary.DeletedIDs = append(summary.DeletedIDs, instanceID)
+						}
 					}
 					return resultFromSummary(summary, warnings, deps.IO.ErrOut), nil
 				}),

--- a/internal/commands/instance/delete/command_test.go
+++ b/internal/commands/instance/delete/command_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/output"
 )
 
-func TestModuleKeepsGeneratedAPIDescriptorAndWorkflowFlag(t *testing.T) {
+func TestModuleKeepsGeneratedAPIDescriptorWithoutWaitFlag(t *testing.T) {
 	module := Module()
 	if module.Descriptor.Generated == nil {
 		t.Fatalf("mixed module missing generated descriptor snapshot")
@@ -36,6 +36,9 @@ func TestModuleKeepsGeneratedAPIDescriptorAndWorkflowFlag(t *testing.T) {
 	}
 	if !hasFlag(module.Descriptor.Spec.Flags, "ignore-not-found") {
 		t.Fatalf("final spec missing --ignore-not-found")
+	}
+	if hasFlag(module.Descriptor.Spec.Flags, "wait") {
+		t.Fatalf("instance.delete must not expose --wait")
 	}
 }
 

--- a/internal/commands/instance/delete/command_test.go
+++ b/internal/commands/instance/delete/command_test.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/apicli"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/internal/resourcewait"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/output"
+	ags "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ags/v20250920"
 )
 
-func TestModuleKeepsGeneratedAPIDescriptorWithoutWaitFlag(t *testing.T) {
+func TestModuleAddsWaitWithoutChangingGeneratedAPIDescriptor(t *testing.T) {
 	module := Module()
 	if module.Descriptor.Generated == nil {
 		t.Fatalf("mixed module missing generated descriptor snapshot")
@@ -37,8 +40,11 @@ func TestModuleKeepsGeneratedAPIDescriptorWithoutWaitFlag(t *testing.T) {
 	if !hasFlag(module.Descriptor.Spec.Flags, "ignore-not-found") {
 		t.Fatalf("final spec missing --ignore-not-found")
 	}
-	if hasFlag(module.Descriptor.Spec.Flags, "wait") {
-		t.Fatalf("instance.delete must not expose --wait")
+	if !hasFlag(module.Descriptor.Spec.Flags, "wait") {
+		t.Fatalf("final spec missing --wait")
+	}
+	if hasFlag(module.Descriptor.Generated.Spec.Flags, "wait") {
+		t.Fatalf("generated API descriptor must not include workflow --wait")
 	}
 }
 
@@ -206,9 +212,13 @@ type fakeControlPlane struct {
 	deleted  []string
 	fail     map[string]error
 	notFound map[string]bool
+	statuses map[string][]string
+	getCalls map[string]int
+	events   []string
 }
 
 func (f *fakeControlPlane) DeleteInstance(_ context.Context, instanceID string) error {
+	f.events = append(f.events, "delete:"+instanceID)
 	if f.notFound[instanceID] {
 		return output.NewNotFoundError("INSTANCE_NOT_FOUND", "missing", "hint")
 	}
@@ -219,9 +229,104 @@ func (f *fakeControlPlane) DeleteInstance(_ context.Context, instanceID string) 
 	return nil
 }
 
+func (f *fakeControlPlane) GetInstance(_ context.Context, instanceID string) (*ags.SandboxInstance, error) {
+	if f.getCalls == nil {
+		f.getCalls = map[string]int{}
+	}
+	f.events = append(f.events, "get:"+instanceID)
+	index := f.getCalls[instanceID]
+	f.getCalls[instanceID]++
+	statuses := f.statuses[instanceID]
+	if len(statuses) == 0 {
+		statuses = []string{"STOPPED"}
+	}
+	if index >= len(statuses) {
+		index = len(statuses) - 1
+	}
+	status := statuses[index]
+	return &ags.SandboxInstance{InstanceId: &instanceID, Status: &status}, nil
+}
+
 func (f *fakeControlPlane) IsNotFound(err error) bool {
 	var cliErr *output.CLIError
 	return errors.As(err, &cliErr) && cliErr.Failure != nil && cliErr.Failure.Kind == output.KindNotFound
+}
+
+func TestModuleWaitSubmitsAllDeletesBeforePolling(t *testing.T) {
+	cp := &fakeControlPlane{statuses: map[string][]string{
+		"ins-a": {"STOPPED"},
+		"ins-b": {"STOPPED"},
+	}}
+	runtime, err := Module().Build(command.Deps{
+		ControlPlane: cp,
+		Values: map[string]any{resourcewait.OptionsKey: resourcewait.Options{
+			Interval: time.Millisecond,
+			Timeout:  50 * time.Millisecond,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	result, err := runtime.Handler.Run(context.Background(), command.Request{
+		Args: []string{"ins-a", "ins-b"},
+		Flags: map[string]command.FlagValue{
+			"wait": {Name: "wait", Type: command.FlagBool, Bool: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	wantEvents := []string{"delete:ins-a", "delete:ins-b", "get:ins-a", "get:ins-b"}
+	if len(cp.events) != len(wantEvents) {
+		t.Fatalf("events = %#v, want %#v", cp.events, wantEvents)
+	}
+	for i := range wantEvents {
+		if cp.events[i] != wantEvents[i] {
+			t.Fatalf("events = %#v, want %#v", cp.events, wantEvents)
+		}
+	}
+	if len(cp.deleted) != 2 {
+		t.Fatalf("mutations = %#v, want exactly two", cp.deleted)
+	}
+	summary := result.Data.(map[string]any)
+	if summary["Deleted"] != 2 || summary["Failed"] != 0 {
+		t.Fatalf("summary = %#v", summary)
+	}
+}
+
+func TestModuleWaitReportsStopFailureAsPartialFailure(t *testing.T) {
+	cp := &fakeControlPlane{statuses: map[string][]string{
+		"ins-a": {"STOPPING_FAILED"},
+	}}
+	runtime, err := Module().Build(command.Deps{
+		ControlPlane: cp,
+		Values: map[string]any{resourcewait.OptionsKey: resourcewait.Options{
+			Interval: time.Millisecond,
+			Timeout:  50 * time.Millisecond,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	result, err := runtime.Handler.Run(context.Background(), command.Request{
+		Args: []string{"ins-a"},
+		Flags: map[string]command.FlagValue{
+			"wait": {Name: "wait", Type: command.FlagBool, Bool: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(cp.deleted) != 1 {
+		t.Fatalf("mutations = %#v, want exactly one", cp.deleted)
+	}
+	if result.ExitCode != output.ExitPartialSuccess || result.Failure == nil {
+		t.Fatalf("result = %#v", result)
+	}
+	summary := result.Data.(map[string]any)
+	if summary["Deleted"] != 0 || summary["Failed"] != 1 {
+		t.Fatalf("summary = %#v", summary)
+	}
 }
 
 func TestModuleDryRunDoesNotDelete(t *testing.T) {

--- a/internal/commands/instance/get/command.go
+++ b/internal/commands/instance/get/command.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
 	instanceview "github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/instance/internal/instanceview"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/internal/resourcewait"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/output"
 	ags "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ags/v20250920"
 )
@@ -26,6 +27,7 @@ func Module() command.Module {
 		Short:        "Get instance details",
 		Long:         "Get detailed information about a specific instance.",
 		Args:         []command.ArgSpec{{Name: "instance-id", Required: true}},
+		Flags:        []command.FlagSpec{resourcewait.Flag()},
 		SupportsJSON: true,
 		Output:       command.OutputSpec{DataType: "Instance"},
 	}
@@ -54,17 +56,29 @@ func Module() command.Module {
 				if strings.TrimSpace(instanceID) == "" {
 					return nil, output.NewUsageError("MISSING_REQUIRED_ARG", "missing instance id", "Provide <instance-id>.")
 				}
-				instance, err := cp.GetInstance(ctx, instanceID)
+				var instance *ags.SandboxInstance
+				var err error
+				if resourcewait.Requested(req) {
+					instance, err = resourcewait.WaitForInstance(ctx, instanceID, cp.GetInstance, resourcewait.OptionsFromDeps(deps))
+				} else {
+					instance, err = cp.GetInstance(ctx, instanceID)
+				}
 				if err != nil {
 					return nil, err
 				}
-				return &command.Result{
-					Data: instanceview.CanonicalData(instance),
-					Text: func(w io.Writer) {
-						renderInstanceDetails(w, instance)
-					},
-				}, nil
+				return Result(instance), nil
 			})}, nil
+		},
+	}
+}
+
+// Result returns the canonical command result for an Instance. Lifecycle
+// mutation commands reuse it after --wait reaches the expected state.
+func Result(instance *ags.SandboxInstance) *command.Result {
+	return &command.Result{
+		Data: instanceview.CanonicalData(instance),
+		Text: func(w io.Writer) {
+			renderInstanceDetails(w, instance)
 		},
 	}
 }

--- a/internal/commands/instance/get/command_test.go
+++ b/internal/commands/instance/get/command_test.go
@@ -5,9 +5,11 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
 	instanceview "github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/instance/internal/instanceview"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/internal/resourcewait"
 	ags "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ags/v20250920"
 )
 
@@ -19,6 +21,9 @@ func TestModuleDescriptor(t *testing.T) {
 	}
 	if !spec.SupportsJSON {
 		t.Fatalf("get should support JSON")
+	}
+	if !hasFlag(spec.Flags, "wait") {
+		t.Fatalf("flags = %#v, want --wait", spec.Flags)
 	}
 }
 
@@ -106,11 +111,64 @@ func TestModuleRejectsMissingInstanceID(t *testing.T) {
 type fakeControlPlane struct {
 	instanceID string
 	instance   *ags.SandboxInstance
+	instances  []*ags.SandboxInstance
+	calls      int
 }
 
 func (f *fakeControlPlane) GetInstance(_ context.Context, instanceID string) (*ags.SandboxInstance, error) {
 	f.instanceID = instanceID
+	f.calls++
+	if len(f.instances) > 0 {
+		index := f.calls - 1
+		if index >= len(f.instances) {
+			index = len(f.instances) - 1
+		}
+		return f.instances[index], nil
+	}
 	return f.instance, nil
+}
+
+func TestModuleWaitsForInstanceTerminalState(t *testing.T) {
+	starting := "STARTING"
+	running := "RUNNING"
+	cp := &fakeControlPlane{instances: []*ags.SandboxInstance{
+		{Status: &starting},
+		{Status: &running},
+	}}
+	runtime, err := Module().Build(command.Deps{
+		ControlPlane: cp,
+		Values: map[string]any{resourcewait.OptionsKey: resourcewait.Options{
+			Interval: time.Millisecond,
+			Timeout:  50 * time.Millisecond,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+	result, err := runtime.Handler.Run(context.Background(), command.Request{
+		Args: []string{"ins-unit"},
+		Flags: map[string]command.FlagValue{
+			"wait": {Name: "wait", Type: command.FlagBool, Bool: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if cp.calls != 2 {
+		t.Fatalf("GetInstance calls = %d, want 2", cp.calls)
+	}
+	if result.Data.(map[string]any)["Status"] != running {
+		t.Fatalf("data = %#v", result.Data)
+	}
+}
+
+func hasFlag(flags []command.FlagSpec, name string) bool {
+	for _, flag := range flags {
+		if flag.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 func TestFormatTimeout(t *testing.T) {

--- a/internal/commands/instance/pause/command.go
+++ b/internal/commands/instance/pause/command.go
@@ -7,17 +7,21 @@ import (
 
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/apicli"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
+	instanceget "github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/instance/get"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/internal/resourcewait"
 )
 
 // Module returns this package's command module.
 func Module() command.Module {
 	api := APIDescriptor()
-	spec := api.CommandSpec()
+	generatedSpec := api.CommandSpec()
+	spec := generatedSpec
+	spec.Flags = append(spec.Flags, resourcewait.Flag())
 	return command.Module{
 		Descriptor: command.Descriptor{
 			Spec: spec,
 			Generated: &command.Descriptor{
-				Spec:   spec,
+				Spec:   generatedSpec,
 				Groups: api.Groups,
 				API:    api,
 				Source: "apicli",
@@ -41,6 +45,17 @@ func Module() command.Module {
 				instanceID := instanceID(req, apiReq)
 				result.Text = func(w io.Writer) {
 					fmt.Fprintf(w, "Instance paused: %s\n", instanceID)
+				}
+				if resourcewait.Requested(req) {
+					getter, ok := deps.ControlPlane.(resourcewait.InstanceGetter)
+					if !ok {
+						return nil, fmt.Errorf("instance.pause --wait requires GetInstance support")
+					}
+					instance, err := resourcewait.WaitForInstance(ctx, instanceID, getter.GetInstance, resourcewait.OptionsFromDeps(deps))
+					if err != nil {
+						return nil, err
+					}
+					return resourcewait.PreserveMutationMetadata(instanceget.Result(instance), result), nil
 				}
 				return result, nil
 			})}, nil

--- a/internal/commands/instance/pause/command.go
+++ b/internal/commands/instance/pause/command.go
@@ -51,7 +51,13 @@ func Module() command.Module {
 					if !ok {
 						return nil, fmt.Errorf("instance.pause --wait requires GetInstance support")
 					}
-					instance, err := resourcewait.WaitForInstance(ctx, instanceID, getter.GetInstance, resourcewait.OptionsFromDeps(deps))
+					instance, err := resourcewait.WaitForInstanceWithPolicy(
+						ctx,
+						instanceID,
+						getter.GetInstance,
+						resourcewait.InstancePolicy(resourcewait.OperationPause),
+						resourcewait.OptionsFromDeps(deps),
+					)
 					if err != nil {
 						return nil, err
 					}

--- a/internal/commands/instance/pause/command_test.go
+++ b/internal/commands/instance/pause/command_test.go
@@ -5,20 +5,31 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/internal/resourcewait"
 	ags "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ags/v20250920"
 )
 
 type fakeMixedControlPlane struct {
-	action  string
-	request map[string]any
+	action   string
+	request  map[string]any
+	calls    int
+	getCalls int
+	status   string
 }
 
 func (f *fakeMixedControlPlane) Call(_ context.Context, action string, request map[string]any) (any, error) {
 	f.action = action
 	f.request = request
+	f.calls++
 	return &ags.PauseSandboxInstanceResponseParams{}, nil
+}
+
+func (f *fakeMixedControlPlane) GetInstance(_ context.Context, instanceID string) (*ags.SandboxInstance, error) {
+	f.getCalls++
+	return &ags.SandboxInstance{InstanceId: &instanceID, Status: &f.status}, nil
 }
 
 func TestModulePausesInstanceAndRendersText(t *testing.T) {
@@ -41,5 +52,29 @@ func TestModulePausesInstanceAndRendersText(t *testing.T) {
 	result.Text(&text)
 	if !strings.Contains(text.String(), "Instance paused: ins-unit") {
 		t.Fatalf("text = %q", text.String())
+	}
+}
+
+func TestModuleWaitsAfterPausingExactlyOnce(t *testing.T) {
+	cp := &fakeMixedControlPlane{status: "PAUSED"}
+	runtime, err := Module().Build(command.Deps{ControlPlane: cp, Values: map[string]any{
+		resourcewait.OptionsKey: resourcewait.Options{Interval: time.Millisecond, Timeout: 50 * time.Millisecond},
+	}})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	result, err := runtime.Handler.Run(context.Background(), command.Request{
+		Args:      []string{"ins-unit"},
+		ArgValues: map[string]string{"instance-id": "ins-unit"},
+		Flags:     map[string]command.FlagValue{"wait": {Name: "wait", Type: command.FlagBool, Bool: true}},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if cp.calls != 1 || cp.getCalls != 1 {
+		t.Fatalf("Call = %d, GetInstance = %d", cp.calls, cp.getCalls)
+	}
+	if result.Data.(map[string]any)["Status"] != "PAUSED" {
+		t.Fatalf("result = %#v", result.Data)
 	}
 }

--- a/internal/commands/instance/pause/command_test.go
+++ b/internal/commands/instance/pause/command_test.go
@@ -20,6 +20,7 @@ type fakeMixedControlPlane struct {
 	calls    int
 	getCalls int
 	status   string
+	statuses []string
 }
 
 func (f *fakeMixedControlPlane) Call(_ context.Context, action string, request map[string]any) (any, error) {
@@ -30,8 +31,16 @@ func (f *fakeMixedControlPlane) Call(_ context.Context, action string, request m
 }
 
 func (f *fakeMixedControlPlane) GetInstance(_ context.Context, instanceID string) (*ags.SandboxInstance, error) {
+	status := f.status
+	if len(f.statuses) > 0 {
+		index := f.getCalls
+		if index >= len(f.statuses) {
+			index = len(f.statuses) - 1
+		}
+		status = f.statuses[index]
+	}
 	f.getCalls++
-	return &ags.SandboxInstance{InstanceId: &instanceID, Status: &f.status}, nil
+	return &ags.SandboxInstance{InstanceId: &instanceID, Status: &status}, nil
 }
 
 func TestModulePausesInstanceAndRendersText(t *testing.T) {
@@ -57,8 +66,8 @@ func TestModulePausesInstanceAndRendersText(t *testing.T) {
 	}
 }
 
-func TestModuleWaitsAfterPausingExactlyOnce(t *testing.T) {
-	cp := &fakeMixedControlPlane{status: "PAUSED"}
+func TestModuleWaitsThroughStaleRunningAfterPausingExactlyOnce(t *testing.T) {
+	cp := &fakeMixedControlPlane{statuses: []string{"RUNNING", "PAUSING", "PAUSED"}}
 	runtime, err := Module().Build(command.Deps{ControlPlane: cp, Values: map[string]any{
 		resourcewait.OptionsKey: resourcewait.Options{Interval: time.Millisecond, Timeout: 50 * time.Millisecond},
 	}})
@@ -73,7 +82,7 @@ func TestModuleWaitsAfterPausingExactlyOnce(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if cp.calls != 1 || cp.getCalls != 1 {
+	if cp.calls != 1 || cp.getCalls != 3 {
 		t.Fatalf("Call = %d, GetInstance = %d", cp.calls, cp.getCalls)
 	}
 	if result.Data.(map[string]any)["Status"] != "PAUSED" {
@@ -82,7 +91,7 @@ func TestModuleWaitsAfterPausingExactlyOnce(t *testing.T) {
 }
 
 func TestModuleWaitReportsBackendRollbackToRunning(t *testing.T) {
-	cp := &fakeMixedControlPlane{status: "RUNNING"}
+	cp := &fakeMixedControlPlane{statuses: []string{"PAUSING", "RUNNING"}}
 	runtime, err := Module().Build(command.Deps{ControlPlane: cp, Values: map[string]any{
 		resourcewait.OptionsKey: resourcewait.Options{Interval: time.Millisecond, Timeout: 50 * time.Millisecond},
 	}})
@@ -98,7 +107,7 @@ func TestModuleWaitReportsBackendRollbackToRunning(t *testing.T) {
 	if !errors.As(err, &cliErr) || cliErr.Failure.Code != "WAIT_FAILED" {
 		t.Fatalf("error = %#v, want WAIT_FAILED", err)
 	}
-	if cp.calls != 1 || cp.getCalls != 1 {
+	if cp.calls != 1 || cp.getCalls != 2 {
 		t.Fatalf("Call = %d, GetInstance = %d", cp.calls, cp.getCalls)
 	}
 }

--- a/internal/commands/instance/pause/command_test.go
+++ b/internal/commands/instance/pause/command_test.go
@@ -3,12 +3,14 @@ package pause
 import (
 	"bytes"
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/internal/resourcewait"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/output"
 	ags "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ags/v20250920"
 )
 
@@ -76,5 +78,27 @@ func TestModuleWaitsAfterPausingExactlyOnce(t *testing.T) {
 	}
 	if result.Data.(map[string]any)["Status"] != "PAUSED" {
 		t.Fatalf("result = %#v", result.Data)
+	}
+}
+
+func TestModuleWaitReportsBackendRollbackToRunning(t *testing.T) {
+	cp := &fakeMixedControlPlane{status: "RUNNING"}
+	runtime, err := Module().Build(command.Deps{ControlPlane: cp, Values: map[string]any{
+		resourcewait.OptionsKey: resourcewait.Options{Interval: time.Millisecond, Timeout: 50 * time.Millisecond},
+	}})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	_, err = runtime.Handler.Run(context.Background(), command.Request{
+		Args:      []string{"ins-unit"},
+		ArgValues: map[string]string{"instance-id": "ins-unit"},
+		Flags:     map[string]command.FlagValue{"wait": {Name: "wait", Type: command.FlagBool, Bool: true}},
+	})
+	var cliErr *output.CLIError
+	if !errors.As(err, &cliErr) || cliErr.Failure.Code != "WAIT_FAILED" {
+		t.Fatalf("error = %#v, want WAIT_FAILED", err)
+	}
+	if cp.calls != 1 || cp.getCalls != 1 {
+		t.Fatalf("Call = %d, GetInstance = %d", cp.calls, cp.getCalls)
 	}
 }

--- a/internal/commands/instance/resume/command.go
+++ b/internal/commands/instance/resume/command.go
@@ -7,17 +7,21 @@ import (
 
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/apicli"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
+	instanceget "github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/instance/get"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/internal/resourcewait"
 )
 
 // Module returns this package's command module.
 func Module() command.Module {
 	api := APIDescriptor()
-	spec := api.CommandSpec()
+	generatedSpec := api.CommandSpec()
+	spec := generatedSpec
+	spec.Flags = append(spec.Flags, resourcewait.Flag())
 	return command.Module{
 		Descriptor: command.Descriptor{
 			Spec: spec,
 			Generated: &command.Descriptor{
-				Spec:   spec,
+				Spec:   generatedSpec,
 				Groups: api.Groups,
 				API:    api,
 				Source: "apicli",
@@ -41,6 +45,17 @@ func Module() command.Module {
 				instanceID := instanceID(req, apiReq)
 				result.Text = func(w io.Writer) {
 					fmt.Fprintf(w, "Instance resumed: %s\n", instanceID)
+				}
+				if resourcewait.Requested(req) {
+					getter, ok := deps.ControlPlane.(resourcewait.InstanceGetter)
+					if !ok {
+						return nil, fmt.Errorf("instance.resume --wait requires GetInstance support")
+					}
+					instance, err := resourcewait.WaitForInstance(ctx, instanceID, getter.GetInstance, resourcewait.OptionsFromDeps(deps))
+					if err != nil {
+						return nil, err
+					}
+					return resourcewait.PreserveMutationMetadata(instanceget.Result(instance), result), nil
 				}
 				return result, nil
 			})}, nil

--- a/internal/commands/instance/resume/command.go
+++ b/internal/commands/instance/resume/command.go
@@ -51,7 +51,13 @@ func Module() command.Module {
 					if !ok {
 						return nil, fmt.Errorf("instance.resume --wait requires GetInstance support")
 					}
-					instance, err := resourcewait.WaitForInstance(ctx, instanceID, getter.GetInstance, resourcewait.OptionsFromDeps(deps))
+					instance, err := resourcewait.WaitForInstanceWithPolicy(
+						ctx,
+						instanceID,
+						getter.GetInstance,
+						resourcewait.InstancePolicy(resourcewait.OperationResume),
+						resourcewait.OptionsFromDeps(deps),
+					)
 					if err != nil {
 						return nil, err
 					}

--- a/internal/commands/instance/resume/command_test.go
+++ b/internal/commands/instance/resume/command_test.go
@@ -5,20 +5,31 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/internal/resourcewait"
 	ags "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ags/v20250920"
 )
 
 type fakeMixedControlPlane struct {
-	action  string
-	request map[string]any
+	action   string
+	request  map[string]any
+	calls    int
+	getCalls int
+	status   string
 }
 
 func (f *fakeMixedControlPlane) Call(_ context.Context, action string, request map[string]any) (any, error) {
 	f.action = action
 	f.request = request
+	f.calls++
 	return &ags.ResumeSandboxInstanceResponseParams{}, nil
+}
+
+func (f *fakeMixedControlPlane) GetInstance(_ context.Context, instanceID string) (*ags.SandboxInstance, error) {
+	f.getCalls++
+	return &ags.SandboxInstance{InstanceId: &instanceID, Status: &f.status}, nil
 }
 
 func TestModuleResumesInstanceAndRendersText(t *testing.T) {
@@ -41,5 +52,29 @@ func TestModuleResumesInstanceAndRendersText(t *testing.T) {
 	result.Text(&text)
 	if !strings.Contains(text.String(), "Instance resumed: ins-unit") {
 		t.Fatalf("text = %q", text.String())
+	}
+}
+
+func TestModuleWaitsAfterResumingExactlyOnce(t *testing.T) {
+	cp := &fakeMixedControlPlane{status: "RUNNING"}
+	runtime, err := Module().Build(command.Deps{ControlPlane: cp, Values: map[string]any{
+		resourcewait.OptionsKey: resourcewait.Options{Interval: time.Millisecond, Timeout: 50 * time.Millisecond},
+	}})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	result, err := runtime.Handler.Run(context.Background(), command.Request{
+		Args:      []string{"ins-unit"},
+		ArgValues: map[string]string{"instance-id": "ins-unit"},
+		Flags:     map[string]command.FlagValue{"wait": {Name: "wait", Type: command.FlagBool, Bool: true}},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if cp.calls != 1 || cp.getCalls != 1 {
+		t.Fatalf("Call = %d, GetInstance = %d", cp.calls, cp.getCalls)
+	}
+	if result.Data.(map[string]any)["Status"] != "RUNNING" {
+		t.Fatalf("result = %#v", result.Data)
 	}
 }

--- a/internal/commands/instance/resume/command_test.go
+++ b/internal/commands/instance/resume/command_test.go
@@ -3,12 +3,14 @@ package resume
 import (
 	"bytes"
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/internal/resourcewait"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/output"
 	ags "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ags/v20250920"
 )
 
@@ -76,5 +78,27 @@ func TestModuleWaitsAfterResumingExactlyOnce(t *testing.T) {
 	}
 	if result.Data.(map[string]any)["Status"] != "RUNNING" {
 		t.Fatalf("result = %#v", result.Data)
+	}
+}
+
+func TestModuleWaitReportsConcurrentStopAsPreempted(t *testing.T) {
+	cp := &fakeMixedControlPlane{status: "STOPPED"}
+	runtime, err := Module().Build(command.Deps{ControlPlane: cp, Values: map[string]any{
+		resourcewait.OptionsKey: resourcewait.Options{Interval: time.Millisecond, Timeout: 50 * time.Millisecond},
+	}})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	_, err = runtime.Handler.Run(context.Background(), command.Request{
+		Args:      []string{"ins-unit"},
+		ArgValues: map[string]string{"instance-id": "ins-unit"},
+		Flags:     map[string]command.FlagValue{"wait": {Name: "wait", Type: command.FlagBool, Bool: true}},
+	})
+	var cliErr *output.CLIError
+	if !errors.As(err, &cliErr) || cliErr.Failure.Code != "WAIT_PREEMPTED" {
+		t.Fatalf("error = %#v, want WAIT_PREEMPTED", err)
+	}
+	if cp.calls != 1 || cp.getCalls != 1 {
+		t.Fatalf("Call = %d, GetInstance = %d", cp.calls, cp.getCalls)
 	}
 }

--- a/internal/commands/instance/update/command.go
+++ b/internal/commands/instance/update/command.go
@@ -7,17 +7,21 @@ import (
 
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/apicli"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
+	instanceget "github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/instance/get"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/internal/resourcewait"
 )
 
 // Module returns this package's command module.
 func Module() command.Module {
 	api := APIDescriptor()
-	spec := api.CommandSpec()
+	generatedSpec := api.CommandSpec()
+	spec := generatedSpec
+	spec.Flags = append(spec.Flags, resourcewait.Flag())
 	return command.Module{
 		Descriptor: command.Descriptor{
 			Spec: spec,
 			Generated: &command.Descriptor{
-				Spec:   spec,
+				Spec:   generatedSpec,
 				Groups: api.Groups,
 				API:    api,
 				Source: "apicli",
@@ -41,6 +45,19 @@ func Module() command.Module {
 				instanceID := instanceID(req, apiReq)
 				result.Text = func(w io.Writer) {
 					fmt.Fprintf(w, "Instance updated: %s\n", instanceID)
+				}
+				if resourcewait.Requested(req) {
+					getter, ok := deps.ControlPlane.(resourcewait.InstanceGetter)
+					if !ok {
+						return nil, fmt.Errorf("instance.update --wait requires GetInstance support")
+					}
+					options := resourcewait.OptionsFromDeps(deps)
+					options.DelayBeforeFirstPoll = true
+					instance, err := resourcewait.WaitForInstance(ctx, instanceID, getter.GetInstance, options)
+					if err != nil {
+						return nil, err
+					}
+					return resourcewait.PreserveMutationMetadata(instanceget.Result(instance), result), nil
 				}
 				return result, nil
 			})}, nil

--- a/internal/commands/instance/update/command.go
+++ b/internal/commands/instance/update/command.go
@@ -51,9 +51,13 @@ func Module() command.Module {
 					if !ok {
 						return nil, fmt.Errorf("instance.update --wait requires GetInstance support")
 					}
-					options := resourcewait.OptionsFromDeps(deps)
-					options.DelayBeforeFirstPoll = true
-					instance, err := resourcewait.WaitForInstance(ctx, instanceID, getter.GetInstance, options)
+					instance, err := resourcewait.WaitForInstanceWithPolicy(
+						ctx,
+						instanceID,
+						getter.GetInstance,
+						resourcewait.InstancePolicy(resourcewait.OperationUpdate),
+						resourcewait.OptionsFromDeps(deps),
+					)
 					if err != nil {
 						return nil, err
 					}

--- a/internal/commands/instance/update/command_test.go
+++ b/internal/commands/instance/update/command_test.go
@@ -5,20 +5,37 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/internal/resourcewait"
 	ags "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ags/v20250920"
 )
 
 type fakeMixedControlPlane struct {
-	action  string
-	request map[string]any
+	action         string
+	request        map[string]any
+	calls          int
+	getCalls       int
+	status         string
+	updateReturned time.Time
+	firstGet       time.Time
 }
 
 func (f *fakeMixedControlPlane) Call(_ context.Context, action string, request map[string]any) (any, error) {
 	f.action = action
 	f.request = request
+	f.calls++
+	f.updateReturned = time.Now()
 	return &ags.UpdateSandboxInstanceResponseParams{}, nil
+}
+
+func (f *fakeMixedControlPlane) GetInstance(_ context.Context, instanceID string) (*ags.SandboxInstance, error) {
+	f.getCalls++
+	if f.firstGet.IsZero() {
+		f.firstGet = time.Now()
+	}
+	return &ags.SandboxInstance{InstanceId: &instanceID, Status: &f.status}, nil
 }
 
 func TestModuleUpdatesInstanceAndRendersText(t *testing.T) {
@@ -44,5 +61,36 @@ func TestModuleUpdatesInstanceAndRendersText(t *testing.T) {
 	result.Text(&text)
 	if !strings.Contains(text.String(), "Instance updated: ins-unit") {
 		t.Fatalf("text = %q", text.String())
+	}
+}
+
+func TestModuleWaitsAfterUpdatingExactlyOnce(t *testing.T) {
+	const interval = 20 * time.Millisecond
+	cp := &fakeMixedControlPlane{status: "RUNNING"}
+	runtime, err := Module().Build(command.Deps{ControlPlane: cp, Values: map[string]any{
+		resourcewait.OptionsKey: resourcewait.Options{Interval: interval, Timeout: 100 * time.Millisecond},
+	}})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	result, err := runtime.Handler.Run(context.Background(), command.Request{
+		Args:      []string{"ins-unit"},
+		ArgValues: map[string]string{"instance-id": "ins-unit"},
+		Flags: map[string]command.FlagValue{
+			"timeout": {Name: "timeout", Type: command.FlagString, String: "10m", Changed: true},
+			"wait":    {Name: "wait", Type: command.FlagBool, Bool: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if cp.calls != 1 || cp.getCalls != 1 {
+		t.Fatalf("Call = %d, GetInstance = %d", cp.calls, cp.getCalls)
+	}
+	if elapsed := cp.firstGet.Sub(cp.updateReturned); elapsed < interval {
+		t.Fatalf("first GetInstance started %s after update returned, want at least %s", elapsed, interval)
+	}
+	if result.Data.(map[string]any)["Status"] != "RUNNING" {
+		t.Fatalf("result = %#v", result.Data)
 	}
 }

--- a/internal/commands/instance/update/command_test.go
+++ b/internal/commands/instance/update/command_test.go
@@ -13,28 +13,22 @@ import (
 )
 
 type fakeMixedControlPlane struct {
-	action         string
-	request        map[string]any
-	calls          int
-	getCalls       int
-	status         string
-	updateReturned time.Time
-	firstGet       time.Time
+	action   string
+	request  map[string]any
+	calls    int
+	getCalls int
+	status   string
 }
 
 func (f *fakeMixedControlPlane) Call(_ context.Context, action string, request map[string]any) (any, error) {
 	f.action = action
 	f.request = request
 	f.calls++
-	f.updateReturned = time.Now()
 	return &ags.UpdateSandboxInstanceResponseParams{}, nil
 }
 
 func (f *fakeMixedControlPlane) GetInstance(_ context.Context, instanceID string) (*ags.SandboxInstance, error) {
 	f.getCalls++
-	if f.firstGet.IsZero() {
-		f.firstGet = time.Now()
-	}
 	return &ags.SandboxInstance{InstanceId: &instanceID, Status: &f.status}, nil
 }
 
@@ -65,10 +59,9 @@ func TestModuleUpdatesInstanceAndRendersText(t *testing.T) {
 }
 
 func TestModuleWaitsAfterUpdatingExactlyOnce(t *testing.T) {
-	const interval = 20 * time.Millisecond
 	cp := &fakeMixedControlPlane{status: "RUNNING"}
 	runtime, err := Module().Build(command.Deps{ControlPlane: cp, Values: map[string]any{
-		resourcewait.OptionsKey: resourcewait.Options{Interval: interval, Timeout: 100 * time.Millisecond},
+		resourcewait.OptionsKey: resourcewait.Options{Interval: 50 * time.Millisecond, Timeout: 10 * time.Millisecond},
 	}})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
@@ -86,9 +79,6 @@ func TestModuleWaitsAfterUpdatingExactlyOnce(t *testing.T) {
 	}
 	if cp.calls != 1 || cp.getCalls != 1 {
 		t.Fatalf("Call = %d, GetInstance = %d", cp.calls, cp.getCalls)
-	}
-	if elapsed := cp.firstGet.Sub(cp.updateReturned); elapsed < interval {
-		t.Fatalf("first GetInstance started %s after update returned, want at least %s", elapsed, interval)
 	}
 	if result.Data.(map[string]any)["Status"] != "RUNNING" {
 		t.Fatalf("result = %#v", result.Data)

--- a/internal/commands/internal/resourcewait/wait.go
+++ b/internal/commands/internal/resourcewait/wait.go
@@ -1,0 +1,222 @@
+// Package resourcewait provides polling for Instance and Tool lifecycle states.
+package resourcewait
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/output"
+	ags "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ags/v20250920"
+)
+
+const (
+	DefaultInterval = 5 * time.Second
+	DefaultTimeout  = 10 * time.Minute
+
+	// OptionsKey allows focused tests to replace the default timing through
+	// command.Deps.Values without exposing timing flags to CLI users.
+	OptionsKey = "resourcewait.options"
+)
+
+var (
+	instanceTransitionalStatuses = statusSet("STARTING", "PAUSING", "STOPPING")
+	instanceStableStatuses       = statusSet(
+		"RUNNING", "PAUSED", "STOPPED", "FAILED", "STARTING_FAILED",
+		"STOPPING_FAILED", "PAUSE_FAILED", "RESUME_FAILED",
+	)
+	toolTransitionalStatuses = statusSet("CREATING", "DELETING")
+	toolStableStatuses       = statusSet("ACTIVE", "FAILED", "ISOLATED")
+)
+
+// Options controls one wait operation.
+type Options struct {
+	Interval             time.Duration
+	Timeout              time.Duration
+	DelayBeforeFirstPoll bool
+}
+
+// InstanceGetter is the control-plane capability needed by Instance waiters.
+type InstanceGetter interface {
+	GetInstance(context.Context, string) (*ags.SandboxInstance, error)
+}
+
+// ToolGetter is the control-plane capability needed by Tool waiters.
+type ToolGetter interface {
+	GetTool(context.Context, string) (*ags.SandboxTool, error)
+}
+
+// Flag returns the shared workflow flag used by supported commands.
+func Flag() command.FlagSpec {
+	return command.FlagSpec{
+		Name:     "wait",
+		Usage:    "Wait until the resource leaves a transitional state",
+		Type:     command.FlagBool,
+		Workflow: true,
+	}
+}
+
+// Requested reports whether --wait was enabled for the request.
+func Requested(req command.Request) bool {
+	value, ok := req.Flags["wait"]
+	return ok && value.Bool
+}
+
+// PreserveMutationMetadata carries side effects and warnings from the one-time
+// mutation onto the final resource result returned after waiting.
+func PreserveMutationMetadata(finalResult, mutationResult *command.Result) *command.Result {
+	if finalResult == nil || mutationResult == nil {
+		return finalResult
+	}
+	finalResult.Warnings = append([]string(nil), mutationResult.Warnings...)
+	finalResult.Effects = append([]output.Effect(nil), mutationResult.Effects...)
+	if mutationResult.MetaExtra != nil {
+		finalResult.MetaExtra = make(map[string]any, len(mutationResult.MetaExtra))
+		for key, value := range mutationResult.MetaExtra {
+			finalResult.MetaExtra[key] = value
+		}
+	}
+	return finalResult
+}
+
+// OptionsFromDeps returns production timing defaults, with a test-only
+// dependency override when supplied by a command module test.
+func OptionsFromDeps(deps command.Deps) Options {
+	options := Options{Interval: DefaultInterval, Timeout: DefaultTimeout}
+	if configured, ok := deps.Values[OptionsKey].(Options); ok {
+		if configured.Interval > 0 {
+			options.Interval = configured.Interval
+		}
+		if configured.Timeout > 0 {
+			options.Timeout = configured.Timeout
+		}
+	}
+	return options
+}
+
+// WaitForInstance polls GetInstance until the instance leaves a transitional
+// state or the operation times out.
+func WaitForInstance(
+	ctx context.Context,
+	instanceID string,
+	get func(context.Context, string) (*ags.SandboxInstance, error),
+	options Options,
+) (*ags.SandboxInstance, error) {
+	return waitFor(ctx, "instance", instanceID, get, func(instance *ags.SandboxInstance) string {
+		if instance == nil || instance.Status == nil {
+			return ""
+		}
+		return *instance.Status
+	}, instanceTransitionalStatuses, instanceStableStatuses, options)
+}
+
+// WaitForTool polls GetTool until the tool leaves a transitional state or the
+// operation times out.
+func WaitForTool(
+	ctx context.Context,
+	toolID string,
+	get func(context.Context, string) (*ags.SandboxTool, error),
+	options Options,
+) (*ags.SandboxTool, error) {
+	return waitFor(ctx, "tool", toolID, get, func(tool *ags.SandboxTool) string {
+		if tool == nil || tool.Status == nil {
+			return ""
+		}
+		return *tool.Status
+	}, toolTransitionalStatuses, toolStableStatuses, options)
+}
+
+func waitFor[T any](
+	ctx context.Context,
+	resourceType string,
+	resourceID string,
+	get func(context.Context, string) (T, error),
+	statusOf func(T) string,
+	transitionalStatuses map[string]struct{},
+	stableStatuses map[string]struct{},
+	options Options,
+) (T, error) {
+	var zero T
+	if options.Interval <= 0 {
+		options.Interval = DefaultInterval
+	}
+	if options.Timeout <= 0 {
+		options.Timeout = DefaultTimeout
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, options.Timeout)
+	defer cancel()
+	lastStatus := ""
+	if options.DelayBeforeFirstPoll {
+		if err := waitForNextPoll(waitCtx, options.Interval); err != nil {
+			return zero, waitContextError(ctx, resourceType, resourceID, lastStatus)
+		}
+	}
+	for {
+		resource, err := get(waitCtx, resourceID)
+		if err != nil {
+			if waitCtx.Err() != nil {
+				return zero, waitContextError(ctx, resourceType, resourceID, lastStatus)
+			}
+			return zero, err
+		}
+
+		lastStatus = strings.TrimSpace(statusOf(resource))
+		normalizedStatus := strings.ToUpper(lastStatus)
+		if _, ok := stableStatuses[normalizedStatus]; ok {
+			return resource, nil
+		}
+		if _, ok := transitionalStatuses[normalizedStatus]; !ok {
+			return zero, unknownStatusError(resourceType, resourceID, lastStatus)
+		}
+
+		if err := waitForNextPoll(waitCtx, options.Interval); err != nil {
+			return zero, waitContextError(ctx, resourceType, resourceID, lastStatus)
+		}
+	}
+}
+
+func statusSet(statuses ...string) map[string]struct{} {
+	set := make(map[string]struct{}, len(statuses))
+	for _, status := range statuses {
+		set[status] = struct{}{}
+	}
+	return set
+}
+
+func unknownStatusError(resourceType, resourceID, status string) error {
+	return output.NewCLIError(&output.Failure{
+		Code:    "WAIT_UNKNOWN_STATUS",
+		Kind:    output.KindGenericError,
+		Message: fmt.Sprintf("%s %s has unknown status %q", resourceType, resourceID, status),
+		Hint:    "Update agr if the service introduced a new resource status.",
+		Details: map[string]any{"ResourceType": resourceType, "ResourceId": resourceID, "LastStatus": status},
+	})
+}
+
+func waitForNextPoll(ctx context.Context, interval time.Duration) error {
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func waitContextError(parent context.Context, resourceType, resourceID, lastStatus string) error {
+	if err := parent.Err(); err != nil {
+		return err
+	}
+	return output.NewCLIError(&output.Failure{
+		Code:      "WAIT_TIMEOUT",
+		Kind:      output.KindTimeout,
+		Message:   fmt.Sprintf("timed out waiting for %s %s", resourceType, resourceID),
+		Hint:      fmt.Sprintf("Run 'agr %s get %s --wait' to continue waiting.", resourceType, resourceID),
+		Retryable: true,
+		Details:   map[string]any{"ResourceType": resourceType, "ResourceId": resourceID, "LastStatus": lastStatus},
+	})
+}

--- a/internal/commands/internal/resourcewait/wait.go
+++ b/internal/commands/internal/resourcewait/wait.go
@@ -21,21 +21,41 @@ const (
 	OptionsKey = "resourcewait.options"
 )
 
-var (
-	instanceTransitionalStatuses = statusSet("STARTING", "PAUSING", "STOPPING")
-	instanceStableStatuses       = statusSet(
-		"RUNNING", "PAUSED", "STOPPED", "FAILED", "STARTING_FAILED",
-		"STOPPING_FAILED", "PAUSE_FAILED", "RESUME_FAILED",
-	)
-	toolTransitionalStatuses = statusSet("CREATING", "DELETING")
-	toolStableStatuses       = statusSet("ACTIVE", "FAILED", "ISOLATED")
+// Operation identifies the command whose outcome a waiter is evaluating.
+type Operation string
+
+const (
+	OperationGet    Operation = "get"
+	OperationCreate Operation = "create"
+	OperationUpdate Operation = "update"
+	OperationPause  Operation = "pause"
+	OperationResume Operation = "resume"
+	OperationDelete Operation = "delete"
+	OperationFork   Operation = "fork"
 )
+
+// Decision describes how a policy interprets one observed status.
+type Decision int
+
+const (
+	Continue Decision = iota
+	Success
+	Failed
+	Preempted
+)
+
+// Policy interprets resource statuses for one operation.
+type Policy struct {
+	Operation         Operation
+	Decide            func(string) Decision
+	NotFoundIsSuccess bool
+}
 
 // Options controls one wait operation.
 type Options struct {
-	Interval             time.Duration
-	Timeout              time.Duration
-	DelayBeforeFirstPoll bool
+	Interval   time.Duration
+	Timeout    time.Duration
+	IsNotFound func(error) bool
 }
 
 // InstanceGetter is the control-plane capability needed by Instance waiters.
@@ -52,7 +72,7 @@ type ToolGetter interface {
 func Flag() command.FlagSpec {
 	return command.FlagSpec{
 		Name:     "wait",
-		Usage:    "Wait until the resource leaves a transitional state",
+		Usage:    "Wait until the requested operation reaches a final outcome",
 		Type:     command.FlagBool,
 		Workflow: true,
 	}
@@ -92,16 +112,50 @@ func OptionsFromDeps(deps command.Deps) Options {
 		if configured.Timeout > 0 {
 			options.Timeout = configured.Timeout
 		}
+		options.IsNotFound = configured.IsNotFound
 	}
 	return options
 }
 
-// WaitForInstance polls GetInstance until the instance leaves a transitional
-// state or the operation times out.
+// InstancePolicy returns the backend-aligned status policy for an Instance
+// operation.
+func InstancePolicy(operation Operation) Policy {
+	return Policy{
+		Operation: operation,
+		Decide: func(status string) Decision {
+			return decideInstanceStatus(operation, normalizeStatus(status))
+		},
+	}
+}
+
+// ToolPolicy returns the backend-aligned status policy for a Tool operation.
+func ToolPolicy(operation Operation) Policy {
+	return Policy{
+		Operation: operation,
+		Decide: func(status string) Decision {
+			return decideToolStatus(operation, normalizeStatus(status))
+		},
+		NotFoundIsSuccess: operation == OperationDelete,
+	}
+}
+
+// WaitForInstance waits for an Instance to reach any non-failure terminal
+// state, which is the contract used by instance get --wait.
 func WaitForInstance(
 	ctx context.Context,
 	instanceID string,
 	get func(context.Context, string) (*ags.SandboxInstance, error),
+	options Options,
+) (*ags.SandboxInstance, error) {
+	return WaitForInstanceWithPolicy(ctx, instanceID, get, InstancePolicy(OperationGet), options)
+}
+
+// WaitForInstanceWithPolicy waits for an Instance operation-specific outcome.
+func WaitForInstanceWithPolicy(
+	ctx context.Context,
+	instanceID string,
+	get func(context.Context, string) (*ags.SandboxInstance, error),
+	policy Policy,
 	options Options,
 ) (*ags.SandboxInstance, error) {
 	return waitFor(ctx, "instance", instanceID, get, func(instance *ags.SandboxInstance) string {
@@ -109,15 +163,26 @@ func WaitForInstance(
 			return ""
 		}
 		return *instance.Status
-	}, instanceTransitionalStatuses, instanceStableStatuses, options)
+	}, policy, options)
 }
 
-// WaitForTool polls GetTool until the tool leaves a transitional state or the
-// operation times out.
+// WaitForTool waits for a Tool to reach any non-failure terminal state, which
+// is the contract used by tool get --wait.
 func WaitForTool(
 	ctx context.Context,
 	toolID string,
 	get func(context.Context, string) (*ags.SandboxTool, error),
+	options Options,
+) (*ags.SandboxTool, error) {
+	return WaitForToolWithPolicy(ctx, toolID, get, ToolPolicy(OperationGet), options)
+}
+
+// WaitForToolWithPolicy waits for a Tool operation-specific outcome.
+func WaitForToolWithPolicy(
+	ctx context.Context,
+	toolID string,
+	get func(context.Context, string) (*ags.SandboxTool, error),
+	policy Policy,
 	options Options,
 ) (*ags.SandboxTool, error) {
 	return waitFor(ctx, "tool", toolID, get, func(tool *ags.SandboxTool) string {
@@ -125,7 +190,7 @@ func WaitForTool(
 			return ""
 		}
 		return *tool.Status
-	}, toolTransitionalStatuses, toolStableStatuses, options)
+	}, policy, options)
 }
 
 func waitFor[T any](
@@ -134,8 +199,7 @@ func waitFor[T any](
 	resourceID string,
 	get func(context.Context, string) (T, error),
 	statusOf func(T) string,
-	transitionalStatuses map[string]struct{},
-	stableStatuses map[string]struct{},
+	policy Policy,
 	options Options,
 ) (T, error) {
 	var zero T
@@ -148,51 +212,166 @@ func waitFor[T any](
 
 	waitCtx, cancel := context.WithTimeout(ctx, options.Timeout)
 	defer cancel()
+
+	startedAt := time.Now()
 	lastStatus := ""
-	if options.DelayBeforeFirstPoll {
-		if err := waitForNextPoll(waitCtx, options.Interval); err != nil {
-			return zero, waitContextError(ctx, resourceType, resourceID, lastStatus)
-		}
-	}
+	attempts := 0
 	for {
+		attempts++
 		resource, err := get(waitCtx, resourceID)
 		if err != nil {
 			if waitCtx.Err() != nil {
-				return zero, waitContextError(ctx, resourceType, resourceID, lastStatus)
+				return zero, waitContextError(ctx, resourceType, resourceID, policy.Operation, lastStatus, attempts, startedAt)
+			}
+			if policy.NotFoundIsSuccess && options.IsNotFound != nil && options.IsNotFound(err) {
+				return zero, nil
 			}
 			return zero, err
 		}
 
 		lastStatus = strings.TrimSpace(statusOf(resource))
-		normalizedStatus := strings.ToUpper(lastStatus)
-		if _, ok := stableStatuses[normalizedStatus]; ok {
+		switch policy.Decide(lastStatus) {
+		case Success:
 			return resource, nil
-		}
-		if _, ok := transitionalStatuses[normalizedStatus]; !ok {
-			return zero, unknownStatusError(resourceType, resourceID, lastStatus)
+		case Failed:
+			return zero, waitStatusError("WAIT_FAILED", output.KindGenericError, resourceType, resourceID, policy.Operation, lastStatus, attempts, startedAt)
+		case Preempted:
+			return zero, waitStatusError("WAIT_PREEMPTED", output.KindConflict, resourceType, resourceID, policy.Operation, lastStatus, attempts, startedAt)
+		case Continue:
 		}
 
 		if err := waitForNextPoll(waitCtx, options.Interval); err != nil {
-			return zero, waitContextError(ctx, resourceType, resourceID, lastStatus)
+			return zero, waitContextError(ctx, resourceType, resourceID, policy.Operation, lastStatus, attempts, startedAt)
 		}
 	}
 }
 
-func statusSet(statuses ...string) map[string]struct{} {
-	set := make(map[string]struct{}, len(statuses))
-	for _, status := range statuses {
-		set[status] = struct{}{}
+func decideInstanceStatus(operation Operation, status string) Decision {
+	switch operation {
+	case OperationCreate:
+		switch status {
+		case "RUNNING":
+			return Success
+		case "FAILED", "STARTING_FAILED", "STOPPING_FAILED", "STOP_FAILED", "PAUSE_FAILED", "RESUME_FAILED":
+			return Failed
+		case "PAUSED", "STOPPED":
+			return Preempted
+		default:
+			return Continue
+		}
+	case OperationUpdate:
+		switch status {
+		case "RUNNING", "PAUSED", "STOPPED":
+			return Success
+		case "FAILED", "STARTING_FAILED", "STOPPING_FAILED", "STOP_FAILED", "PAUSE_FAILED", "RESUME_FAILED":
+			return Failed
+		default:
+			return Continue
+		}
+	case OperationPause:
+		switch status {
+		case "PAUSED":
+			return Success
+		case "RUNNING", "FAILED", "STARTING_FAILED", "PAUSE_FAILED", "RESUME_FAILED":
+			return Failed
+		case "STOPPED", "STOPPING_FAILED", "STOP_FAILED":
+			return Preempted
+		default:
+			return Continue
+		}
+	case OperationResume:
+		switch status {
+		case "RUNNING":
+			return Success
+		case "FAILED", "STARTING_FAILED", "PAUSE_FAILED", "RESUME_FAILED":
+			return Failed
+		case "STOPPED", "STOPPING_FAILED", "STOP_FAILED":
+			return Preempted
+		default:
+			return Continue
+		}
+	case OperationDelete:
+		switch status {
+		case "STOPPED":
+			return Success
+		case "STOPPING_FAILED", "STOP_FAILED":
+			return Failed
+		default:
+			return Continue
+		}
+	default:
+		switch status {
+		case "RUNNING", "PAUSED", "STOPPED":
+			return Success
+		case "FAILED", "STARTING_FAILED", "STOPPING_FAILED", "STOP_FAILED", "PAUSE_FAILED", "RESUME_FAILED":
+			return Failed
+		default:
+			return Continue
+		}
 	}
-	return set
 }
 
-func unknownStatusError(resourceType, resourceID, status string) error {
+func decideToolStatus(operation Operation, status string) Decision {
+	switch operation {
+	case OperationCreate, OperationFork:
+		switch status {
+		case "ACTIVE":
+			return Success
+		case "FAILED":
+			return Failed
+		case "ISOLATED":
+			return Preempted
+		default:
+			return Continue
+		}
+	case OperationUpdate:
+		switch status {
+		case "ACTIVE", "ISOLATED":
+			return Success
+		case "FAILED":
+			return Failed
+		default:
+			return Continue
+		}
+	case OperationDelete:
+		return Continue
+	default:
+		switch status {
+		case "ACTIVE", "ISOLATED":
+			return Success
+		case "FAILED":
+			return Failed
+		default:
+			return Continue
+		}
+	}
+}
+
+func normalizeStatus(status string) string {
+	return strings.ToUpper(strings.TrimSpace(status))
+}
+
+func waitStatusError(
+	code string,
+	kind string,
+	resourceType string,
+	resourceID string,
+	operation Operation,
+	status string,
+	attempts int,
+	startedAt time.Time,
+) error {
+	message := fmt.Sprintf("%s %s %s finished with status %q", resourceType, resourceID, operation, status)
+	hint := fmt.Sprintf("Inspect the resource with 'agr %s get %s'.", resourceType, resourceID)
+	if code == "WAIT_PREEMPTED" {
+		message = fmt.Sprintf("%s %s %s was preempted; current status is %q", resourceType, resourceID, operation, status)
+	}
 	return output.NewCLIError(&output.Failure{
-		Code:    "WAIT_UNKNOWN_STATUS",
-		Kind:    output.KindGenericError,
-		Message: fmt.Sprintf("%s %s has unknown status %q", resourceType, resourceID, status),
-		Hint:    "Update agr if the service introduced a new resource status.",
-		Details: map[string]any{"ResourceType": resourceType, "ResourceId": resourceID, "LastStatus": status},
+		Code:    code,
+		Kind:    kind,
+		Message: message,
+		Hint:    hint,
+		Details: waitDetails(resourceType, resourceID, operation, status, attempts, startedAt),
 	})
 }
 
@@ -207,16 +386,42 @@ func waitForNextPoll(ctx context.Context, interval time.Duration) error {
 	}
 }
 
-func waitContextError(parent context.Context, resourceType, resourceID, lastStatus string) error {
+func waitContextError(
+	parent context.Context,
+	resourceType string,
+	resourceID string,
+	operation Operation,
+	lastStatus string,
+	attempts int,
+	startedAt time.Time,
+) error {
 	if err := parent.Err(); err != nil {
 		return err
 	}
 	return output.NewCLIError(&output.Failure{
 		Code:      "WAIT_TIMEOUT",
 		Kind:      output.KindTimeout,
-		Message:   fmt.Sprintf("timed out waiting for %s %s", resourceType, resourceID),
+		Message:   fmt.Sprintf("timed out waiting for %s %s %s", resourceType, resourceID, operation),
 		Hint:      fmt.Sprintf("Run 'agr %s get %s --wait' to continue waiting.", resourceType, resourceID),
 		Retryable: true,
-		Details:   map[string]any{"ResourceType": resourceType, "ResourceId": resourceID, "LastStatus": lastStatus},
+		Details:   waitDetails(resourceType, resourceID, operation, lastStatus, attempts, startedAt),
 	})
+}
+
+func waitDetails(
+	resourceType string,
+	resourceID string,
+	operation Operation,
+	lastStatus string,
+	attempts int,
+	startedAt time.Time,
+) map[string]any {
+	return map[string]any{
+		"ResourceType": resourceType,
+		"ResourceId":   resourceID,
+		"Operation":    string(operation),
+		"LastStatus":   lastStatus,
+		"Attempts":     attempts,
+		"Elapsed":      time.Since(startedAt).Round(time.Millisecond).String(),
+	}
 }

--- a/internal/commands/internal/resourcewait/wait.go
+++ b/internal/commands/internal/resourcewait/wait.go
@@ -44,10 +44,18 @@ const (
 	Preempted
 )
 
+// Observation captures the current status and whether operation progress has
+// already been observed during this wait.
+type Observation struct {
+	Status             string
+	InProgressObserved bool
+}
+
 // Policy interprets resource statuses for one operation.
 type Policy struct {
 	Operation         Operation
-	Decide            func(string) Decision
+	Decide            func(Observation) Decision
+	IsInProgress      func(string) bool
 	NotFoundIsSuccess bool
 }
 
@@ -120,20 +128,26 @@ func OptionsFromDeps(deps command.Deps) Options {
 // InstancePolicy returns the backend-aligned status policy for an Instance
 // operation.
 func InstancePolicy(operation Operation) Policy {
-	return Policy{
+	policy := Policy{
 		Operation: operation,
-		Decide: func(status string) Decision {
-			return decideInstanceStatus(operation, normalizeStatus(status))
+		Decide: func(observation Observation) Decision {
+			return decideInstanceStatus(operation, normalizeStatus(observation.Status), observation.InProgressObserved)
 		},
 	}
+	if operation == OperationPause {
+		policy.IsInProgress = func(status string) bool {
+			return normalizeStatus(status) == "PAUSING"
+		}
+	}
+	return policy
 }
 
 // ToolPolicy returns the backend-aligned status policy for a Tool operation.
 func ToolPolicy(operation Operation) Policy {
 	return Policy{
 		Operation: operation,
-		Decide: func(status string) Decision {
-			return decideToolStatus(operation, normalizeStatus(status))
+		Decide: func(observation Observation) Decision {
+			return decideToolStatus(operation, normalizeStatus(observation.Status))
 		},
 		NotFoundIsSuccess: operation == OperationDelete,
 	}
@@ -216,6 +230,7 @@ func waitFor[T any](
 	startedAt := time.Now()
 	lastStatus := ""
 	attempts := 0
+	inProgressObserved := false
 	for {
 		attempts++
 		resource, err := get(waitCtx, resourceID)
@@ -226,11 +241,14 @@ func waitFor[T any](
 			if policy.NotFoundIsSuccess && options.IsNotFound != nil && options.IsNotFound(err) {
 				return zero, nil
 			}
-			return zero, err
+			return zero, annotateWaitError(err, resourceType, resourceID, policy.Operation, lastStatus, attempts, startedAt)
 		}
 
 		lastStatus = strings.TrimSpace(statusOf(resource))
-		switch policy.Decide(lastStatus) {
+		if policy.IsInProgress != nil && policy.IsInProgress(lastStatus) {
+			inProgressObserved = true
+		}
+		switch policy.Decide(Observation{Status: lastStatus, InProgressObserved: inProgressObserved}) {
 		case Success:
 			return resource, nil
 		case Failed:
@@ -246,7 +264,47 @@ func waitFor[T any](
 	}
 }
 
-func decideInstanceStatus(operation Operation, status string) Decision {
+type annotatedWaitError struct {
+	cause      error
+	classified *output.CLIError
+}
+
+func (e *annotatedWaitError) Error() string { return e.cause.Error() }
+
+func (e *annotatedWaitError) Unwrap() []error { return []error{e.classified, e.cause} }
+
+func annotateWaitError(
+	err error,
+	resourceType string,
+	resourceID string,
+	operation Operation,
+	lastStatus string,
+	attempts int,
+	startedAt time.Time,
+) error {
+	classified := output.ClassifyError(err)
+	failure := *classified.Failure
+	details := make(map[string]any, len(failure.Details)+6)
+	for key, value := range failure.Details {
+		details[key] = value
+	}
+	for key, value := range waitDetails(resourceType, resourceID, operation, lastStatus, attempts, startedAt) {
+		if _, exists := details[key]; !exists {
+			details[key] = value
+		}
+	}
+	failure.Details = details
+
+	return &annotatedWaitError{
+		cause: err,
+		classified: &output.CLIError{
+			Failure:  &failure,
+			ExitCode: classified.ExitCode,
+		},
+	}
+}
+
+func decideInstanceStatus(operation Operation, status string, inProgressObserved bool) Decision {
 	switch operation {
 	case OperationCreate:
 		switch status {
@@ -272,7 +330,12 @@ func decideInstanceStatus(operation Operation, status string) Decision {
 		switch status {
 		case "PAUSED":
 			return Success
-		case "RUNNING", "FAILED", "STARTING_FAILED", "PAUSE_FAILED", "RESUME_FAILED":
+		case "RUNNING":
+			if inProgressObserved {
+				return Failed
+			}
+			return Continue
+		case "FAILED", "STARTING_FAILED", "PAUSE_FAILED", "RESUME_FAILED":
 			return Failed
 		case "STOPPED", "STOPPING_FAILED", "STOP_FAILED":
 			return Preempted

--- a/internal/commands/internal/resourcewait/wait_test.go
+++ b/internal/commands/internal/resourcewait/wait_test.go
@@ -1,0 +1,195 @@
+package resourcewait
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/output"
+	ags "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ags/v20250920"
+)
+
+func TestDefaults(t *testing.T) {
+	if DefaultInterval != 5*time.Second {
+		t.Fatalf("DefaultInterval = %s, want 5s", DefaultInterval)
+	}
+	if DefaultTimeout != 10*time.Minute {
+		t.Fatalf("DefaultTimeout = %s, want 10m", DefaultTimeout)
+	}
+}
+
+func TestWaitFlagAndRequested(t *testing.T) {
+	flag := Flag()
+	if flag.Name != "wait" || flag.Type != command.FlagBool || !flag.Workflow {
+		t.Fatalf("Flag() = %#v", flag)
+	}
+	if flag.Usage != "Wait until the resource leaves a transitional state" {
+		t.Fatalf("Flag().Usage = %q", flag.Usage)
+	}
+	if !Requested(command.Request{Flags: map[string]command.FlagValue{
+		"wait": {Name: "wait", Type: command.FlagBool, Bool: true},
+	}}) {
+		t.Fatal("Requested should report true for --wait")
+	}
+}
+
+func TestWaitForInstancePollsUntilStableState(t *testing.T) {
+	statuses := []string{"STARTING", "RUNNING"}
+	calls := 0
+	got, err := WaitForInstance(context.Background(), "ins-1", func(context.Context, string) (*ags.SandboxInstance, error) {
+		status := statuses[calls]
+		calls++
+		return &ags.SandboxInstance{Status: &status}, nil
+	}, testOptions())
+	if err != nil {
+		t.Fatalf("WaitForInstance returned error: %v", err)
+	}
+	if calls != 2 || got == nil || got.Status == nil || *got.Status != "RUNNING" {
+		t.Fatalf("calls = %d, instance = %#v", calls, got)
+	}
+}
+
+func TestWaitForToolPollsUntilStableState(t *testing.T) {
+	statuses := []string{"CREATING", "ACTIVE"}
+	calls := 0
+	got, err := WaitForTool(context.Background(), "tool-1", func(context.Context, string) (*ags.SandboxTool, error) {
+		status := statuses[calls]
+		calls++
+		return &ags.SandboxTool{Status: &status}, nil
+	}, testOptions())
+	if err != nil {
+		t.Fatalf("WaitForTool returned error: %v", err)
+	}
+	if calls != 2 || got == nil || got.Status == nil || *got.Status != "ACTIVE" {
+		t.Fatalf("calls = %d, tool = %#v", calls, got)
+	}
+}
+
+func TestWaitForToolCanDelayFirstPoll(t *testing.T) {
+	const interval = 20 * time.Millisecond
+	startedAt := time.Now()
+	status := "ACTIVE"
+	_, err := WaitForTool(context.Background(), "tool-1", func(context.Context, string) (*ags.SandboxTool, error) {
+		if elapsed := time.Since(startedAt); elapsed < interval {
+			t.Fatalf("first poll started after %s, want at least %s", elapsed, interval)
+		}
+		return &ags.SandboxTool{Status: &status}, nil
+	}, Options{
+		Interval:             interval,
+		Timeout:              100 * time.Millisecond,
+		DelayBeforeFirstPoll: true,
+	})
+	if err != nil {
+		t.Fatalf("WaitForTool returned error: %v", err)
+	}
+}
+
+func TestWaitForInstanceReturnsEveryKnownStableState(t *testing.T) {
+	statuses := []string{
+		"RUNNING", "PAUSED", "STOPPED", "FAILED", "STARTING_FAILED",
+		"STOPPING_FAILED", "PAUSE_FAILED", "RESUME_FAILED",
+	}
+	for _, status := range statuses {
+		t.Run(status, func(t *testing.T) {
+			calls := 0
+			got, err := WaitForInstance(context.Background(), "ins-1", func(context.Context, string) (*ags.SandboxInstance, error) {
+				calls++
+				return &ags.SandboxInstance{Status: &status}, nil
+			}, testOptions())
+			if err != nil {
+				t.Fatalf("WaitForInstance returned error: %v", err)
+			}
+			if calls != 1 || got == nil || got.Status == nil || *got.Status != status {
+				t.Fatalf("calls = %d, instance = %#v", calls, got)
+			}
+		})
+	}
+}
+
+func TestWaitForToolReturnsEveryKnownStableState(t *testing.T) {
+	statuses := []string{"ACTIVE", "FAILED", "ISOLATED"}
+	for _, status := range statuses {
+		t.Run(status, func(t *testing.T) {
+			calls := 0
+			got, err := WaitForTool(context.Background(), "tool-1", func(context.Context, string) (*ags.SandboxTool, error) {
+				calls++
+				return &ags.SandboxTool{Status: &status}, nil
+			}, testOptions())
+			if err != nil {
+				t.Fatalf("WaitForTool returned error: %v", err)
+			}
+			if calls != 1 || got == nil || got.Status == nil || *got.Status != status {
+				t.Fatalf("calls = %d, tool = %#v", calls, got)
+			}
+		})
+	}
+}
+
+func TestWaitForInstanceRecognizesEveryTransitionalState(t *testing.T) {
+	for _, transitional := range []string{"STARTING", "PAUSING", "STOPPING"} {
+		t.Run(transitional, func(t *testing.T) {
+			statuses := []string{transitional, "RUNNING"}
+			calls := 0
+			_, err := WaitForInstance(context.Background(), "ins-1", func(context.Context, string) (*ags.SandboxInstance, error) {
+				status := statuses[calls]
+				calls++
+				return &ags.SandboxInstance{Status: &status}, nil
+			}, testOptions())
+			if err != nil || calls != 2 {
+				t.Fatalf("calls = %d, error = %v", calls, err)
+			}
+		})
+	}
+}
+
+func TestWaitForToolRecognizesEveryTransitionalState(t *testing.T) {
+	for _, transitional := range []string{"CREATING", "DELETING"} {
+		t.Run(transitional, func(t *testing.T) {
+			statuses := []string{transitional, "ACTIVE"}
+			calls := 0
+			_, err := WaitForTool(context.Background(), "tool-1", func(context.Context, string) (*ags.SandboxTool, error) {
+				status := statuses[calls]
+				calls++
+				return &ags.SandboxTool{Status: &status}, nil
+			}, testOptions())
+			if err != nil || calls != 2 {
+				t.Fatalf("calls = %d, error = %v", calls, err)
+			}
+		})
+	}
+}
+
+func TestWaitForInstanceRejectsUnknownState(t *testing.T) {
+	status := "NEW_SERVER_STATE"
+	_, err := WaitForInstance(context.Background(), "ins-1", func(context.Context, string) (*ags.SandboxInstance, error) {
+		return &ags.SandboxInstance{Status: &status}, nil
+	}, testOptions())
+	var cliErr *output.CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("error = %T %v, want *output.CLIError", err, err)
+	}
+	if cliErr.Failure.Code != "WAIT_UNKNOWN_STATUS" || cliErr.Failure.Kind != output.KindGenericError || cliErr.Failure.Details["LastStatus"] != status {
+		t.Fatalf("failure = %#v", cliErr.Failure)
+	}
+}
+
+func TestWaitStopsWhenParentContextIsCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	status := "STARTING"
+	_, err := WaitForInstance(ctx, "ins-1", func(context.Context, string) (*ags.SandboxInstance, error) {
+		cancel()
+		return &ags.SandboxInstance{Status: &status}, nil
+	}, testOptions())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+}
+
+func testOptions() Options {
+	return Options{
+		Interval: time.Millisecond,
+		Timeout:  50 * time.Millisecond,
+	}
+}

--- a/internal/commands/internal/resourcewait/wait_test.go
+++ b/internal/commands/internal/resourcewait/wait_test.go
@@ -99,7 +99,7 @@ func TestWaitForToolGetReturnsFailedAsError(t *testing.T) {
 
 func TestWaitForInstancePauseUsesOperationOutcome(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		statuses := []string{"PAUSING", "PAUSED"}
+		statuses := []string{"RUNNING", "PAUSING", "PAUSED"}
 		calls := 0
 		got, err := WaitForInstanceWithPolicy(
 			context.Background(),
@@ -112,12 +112,32 @@ func TestWaitForInstancePauseUsesOperationOutcome(t *testing.T) {
 			InstancePolicy(OperationPause),
 			testOptions(),
 		)
-		if err != nil || calls != 2 || got == nil || got.Status == nil || *got.Status != "PAUSED" {
+		if err != nil || calls != 3 || got == nil || got.Status == nil || *got.Status != "PAUSED" {
 			t.Fatalf("calls = %d, instance = %#v, error = %v", calls, got, err)
 		}
 	})
 
 	t.Run("backend rollback to running", func(t *testing.T) {
+		statuses := []string{"PAUSING", "RUNNING"}
+		calls := 0
+		_, err := WaitForInstanceWithPolicy(
+			context.Background(),
+			"ins-1",
+			func(context.Context, string) (*ags.SandboxInstance, error) {
+				status := statuses[calls]
+				calls++
+				return &ags.SandboxInstance{Status: &status}, nil
+			},
+			InstancePolicy(OperationPause),
+			testOptions(),
+		)
+		assertWaitError(t, err, "WAIT_FAILED", "RUNNING", OperationPause)
+		if calls != 2 {
+			t.Fatalf("calls = %d, want 2", calls)
+		}
+	})
+
+	t.Run("running without observed progress times out", func(t *testing.T) {
 		_, err := WaitForInstanceWithPolicy(
 			context.Background(),
 			"ins-1",
@@ -125,7 +145,7 @@ func TestWaitForInstancePauseUsesOperationOutcome(t *testing.T) {
 			InstancePolicy(OperationPause),
 			testOptions(),
 		)
-		assertWaitError(t, err, "WAIT_FAILED", "RUNNING", OperationPause)
+		assertWaitError(t, err, "WAIT_TIMEOUT", "RUNNING", OperationPause)
 	})
 
 	t.Run("preempted by stop", func(t *testing.T) {
@@ -258,6 +278,49 @@ func TestWaitForToolDeleteTreatsOnlyNotFoundAsSuccess(t *testing.T) {
 		)
 		if !errors.Is(err, want) {
 			t.Fatalf("error = %v, want %v", err, want)
+		}
+		var cliErr *output.CLIError
+		if !errors.As(err, &cliErr) || cliErr.Failure.Details["ResourceId"] != "tool-1" {
+			t.Fatalf("error = %T %v, failure = %#v", err, err, cliErr)
+		}
+	})
+
+	t.Run("CLI error details", func(t *testing.T) {
+		options := testOptions()
+		options.IsNotFound = isNotFoundError
+		want := output.NewCLIError(&output.Failure{
+			Code:      "GET_FAILED",
+			Kind:      output.KindNetwork,
+			Message:   "network down",
+			Hint:      "retry",
+			Retryable: true,
+			Details:   map[string]any{"RequestId": "req-1"},
+		})
+		_, err := WaitForToolWithPolicy(
+			context.Background(),
+			"tool-1",
+			func(context.Context, string) (*ags.SandboxTool, error) {
+				return nil, want
+			},
+			ToolPolicy(OperationDelete),
+			options,
+		)
+		if !errors.Is(err, want) {
+			t.Fatalf("error = %v, want %v", err, want)
+		}
+		var cliErr *output.CLIError
+		if !errors.As(err, &cliErr) {
+			t.Fatalf("error = %T %v, want *output.CLIError", err, err)
+		}
+		if cliErr.Failure.Code != "GET_FAILED" || cliErr.Failure.Kind != output.KindNetwork || !cliErr.Failure.Retryable {
+			t.Fatalf("failure = %#v", cliErr.Failure)
+		}
+		details := cliErr.Failure.Details
+		if details["RequestId"] != "req-1" || details["ResourceType"] != "tool" || details["ResourceId"] != "tool-1" {
+			t.Fatalf("details = %#v", details)
+		}
+		if details["Operation"] != string(OperationDelete) || details["LastStatus"] != "" || details["Attempts"] != 1 {
+			t.Fatalf("wait details = %#v", details)
 		}
 	})
 }

--- a/internal/commands/internal/resourcewait/wait_test.go
+++ b/internal/commands/internal/resourcewait/wait_test.go
@@ -25,7 +25,7 @@ func TestWaitFlagAndRequested(t *testing.T) {
 	if flag.Name != "wait" || flag.Type != command.FlagBool || !flag.Workflow {
 		t.Fatalf("Flag() = %#v", flag)
 	}
-	if flag.Usage != "Wait until the resource leaves a transitional state" {
+	if flag.Usage != "Wait until the requested operation reaches a final outcome" {
 		t.Fatalf("Flag().Usage = %q", flag.Usage)
 	}
 	if !Requested(command.Request{Flags: map[string]command.FlagValue{
@@ -35,7 +35,7 @@ func TestWaitFlagAndRequested(t *testing.T) {
 	}
 }
 
-func TestWaitForInstancePollsUntilStableState(t *testing.T) {
+func TestWaitForInstanceGetPollsUntilNonFailureTerminalState(t *testing.T) {
 	statuses := []string{"STARTING", "RUNNING"}
 	calls := 0
 	got, err := WaitForInstance(context.Background(), "ins-1", func(context.Context, string) (*ags.SandboxInstance, error) {
@@ -51,7 +51,7 @@ func TestWaitForInstancePollsUntilStableState(t *testing.T) {
 	}
 }
 
-func TestWaitForToolPollsUntilStableState(t *testing.T) {
+func TestWaitForToolGetPollsUntilNonFailureTerminalState(t *testing.T) {
 	statuses := []string{"CREATING", "ACTIVE"}
 	calls := 0
 	got, err := WaitForTool(context.Background(), "tool-1", func(context.Context, string) (*ags.SandboxTool, error) {
@@ -67,112 +67,199 @@ func TestWaitForToolPollsUntilStableState(t *testing.T) {
 	}
 }
 
-func TestWaitForToolCanDelayFirstPoll(t *testing.T) {
-	const interval = 20 * time.Millisecond
-	startedAt := time.Now()
+func TestWaitPollsImmediately(t *testing.T) {
 	status := "ACTIVE"
 	_, err := WaitForTool(context.Background(), "tool-1", func(context.Context, string) (*ags.SandboxTool, error) {
-		if elapsed := time.Since(startedAt); elapsed < interval {
-			t.Fatalf("first poll started after %s, want at least %s", elapsed, interval)
-		}
 		return &ags.SandboxTool{Status: &status}, nil
 	}, Options{
-		Interval:             interval,
-		Timeout:              100 * time.Millisecond,
-		DelayBeforeFirstPoll: true,
+		Interval: 50 * time.Millisecond,
+		Timeout:  10 * time.Millisecond,
 	})
 	if err != nil {
-		t.Fatalf("WaitForTool returned error: %v", err)
+		t.Fatalf("WaitForTool returned error before its immediate first poll: %v", err)
 	}
 }
 
-func TestWaitForInstanceReturnsEveryKnownStableState(t *testing.T) {
-	statuses := []string{
-		"RUNNING", "PAUSED", "STOPPED", "FAILED", "STARTING_FAILED",
-		"STOPPING_FAILED", "PAUSE_FAILED", "RESUME_FAILED",
-	}
-	for _, status := range statuses {
+func TestWaitForInstanceGetReturnsFailureStateAsError(t *testing.T) {
+	for _, status := range []string{
+		"FAILED", "STARTING_FAILED", "STOPPING_FAILED", "STOP_FAILED",
+		"PAUSE_FAILED", "RESUME_FAILED",
+	} {
 		t.Run(status, func(t *testing.T) {
-			calls := 0
-			got, err := WaitForInstance(context.Background(), "ins-1", func(context.Context, string) (*ags.SandboxInstance, error) {
-				calls++
-				return &ags.SandboxInstance{Status: &status}, nil
-			}, testOptions())
-			if err != nil {
-				t.Fatalf("WaitForInstance returned error: %v", err)
-			}
-			if calls != 1 || got == nil || got.Status == nil || *got.Status != status {
-				t.Fatalf("calls = %d, instance = %#v", calls, got)
-			}
+			_, err := WaitForInstance(context.Background(), "ins-1", instanceStatusGetter(status), testOptions())
+			assertWaitError(t, err, "WAIT_FAILED", status, OperationGet)
 		})
 	}
 }
 
-func TestWaitForToolReturnsEveryKnownStableState(t *testing.T) {
-	statuses := []string{"ACTIVE", "FAILED", "ISOLATED"}
-	for _, status := range statuses {
-		t.Run(status, func(t *testing.T) {
-			calls := 0
-			got, err := WaitForTool(context.Background(), "tool-1", func(context.Context, string) (*ags.SandboxTool, error) {
-				calls++
-				return &ags.SandboxTool{Status: &status}, nil
-			}, testOptions())
-			if err != nil {
-				t.Fatalf("WaitForTool returned error: %v", err)
-			}
-			if calls != 1 || got == nil || got.Status == nil || *got.Status != status {
-				t.Fatalf("calls = %d, tool = %#v", calls, got)
-			}
-		})
-	}
+func TestWaitForToolGetReturnsFailedAsError(t *testing.T) {
+	_, err := WaitForTool(context.Background(), "tool-1", toolStatusGetter("FAILED"), testOptions())
+	assertWaitError(t, err, "WAIT_FAILED", "FAILED", OperationGet)
 }
 
-func TestWaitForInstanceRecognizesEveryTransitionalState(t *testing.T) {
-	for _, transitional := range []string{"STARTING", "PAUSING", "STOPPING"} {
-		t.Run(transitional, func(t *testing.T) {
-			statuses := []string{transitional, "RUNNING"}
-			calls := 0
-			_, err := WaitForInstance(context.Background(), "ins-1", func(context.Context, string) (*ags.SandboxInstance, error) {
+func TestWaitForInstancePauseUsesOperationOutcome(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		statuses := []string{"PAUSING", "PAUSED"}
+		calls := 0
+		got, err := WaitForInstanceWithPolicy(
+			context.Background(),
+			"ins-1",
+			func(context.Context, string) (*ags.SandboxInstance, error) {
 				status := statuses[calls]
 				calls++
 				return &ags.SandboxInstance{Status: &status}, nil
-			}, testOptions())
-			if err != nil || calls != 2 {
-				t.Fatalf("calls = %d, error = %v", calls, err)
-			}
+			},
+			InstancePolicy(OperationPause),
+			testOptions(),
+		)
+		if err != nil || calls != 2 || got == nil || got.Status == nil || *got.Status != "PAUSED" {
+			t.Fatalf("calls = %d, instance = %#v, error = %v", calls, got, err)
+		}
+	})
+
+	t.Run("backend rollback to running", func(t *testing.T) {
+		_, err := WaitForInstanceWithPolicy(
+			context.Background(),
+			"ins-1",
+			instanceStatusGetter("RUNNING"),
+			InstancePolicy(OperationPause),
+			testOptions(),
+		)
+		assertWaitError(t, err, "WAIT_FAILED", "RUNNING", OperationPause)
+	})
+
+	t.Run("preempted by stop", func(t *testing.T) {
+		_, err := WaitForInstanceWithPolicy(
+			context.Background(),
+			"ins-1",
+			instanceStatusGetter("STOPPED"),
+			InstancePolicy(OperationPause),
+			testOptions(),
+		)
+		assertWaitError(t, err, "WAIT_PREEMPTED", "STOPPED", OperationPause)
+	})
+}
+
+func TestWaitForInstanceResumeUsesOperationOutcome(t *testing.T) {
+	_, err := WaitForInstanceWithPolicy(
+		context.Background(),
+		"ins-1",
+		instanceStatusGetter("RESUME_FAILED"),
+		InstancePolicy(OperationResume),
+		testOptions(),
+	)
+	assertWaitError(t, err, "WAIT_FAILED", "RESUME_FAILED", OperationResume)
+}
+
+func TestWaitForInstanceDeleteAcceptsBothStopFailureNames(t *testing.T) {
+	for _, status := range []string{"STOPPING_FAILED", "STOP_FAILED"} {
+		t.Run(status, func(t *testing.T) {
+			_, err := WaitForInstanceWithPolicy(
+				context.Background(),
+				"ins-1",
+				instanceStatusGetter(status),
+				InstancePolicy(OperationDelete),
+				testOptions(),
+			)
+			assertWaitError(t, err, "WAIT_FAILED", status, OperationDelete)
 		})
 	}
 }
 
-func TestWaitForToolRecognizesEveryTransitionalState(t *testing.T) {
-	for _, transitional := range []string{"CREATING", "DELETING"} {
-		t.Run(transitional, func(t *testing.T) {
-			statuses := []string{transitional, "ACTIVE"}
-			calls := 0
-			_, err := WaitForTool(context.Background(), "tool-1", func(context.Context, string) (*ags.SandboxTool, error) {
-				status := statuses[calls]
-				calls++
-				return &ags.SandboxTool{Status: &status}, nil
-			}, testOptions())
-			if err != nil || calls != 2 {
-				t.Fatalf("calls = %d, error = %v", calls, err)
-			}
-		})
+func TestWaitForToolCreateTreatsIsolatedAsUnavailable(t *testing.T) {
+	_, err := WaitForToolWithPolicy(
+		context.Background(),
+		"tool-1",
+		toolStatusGetter("ISOLATED"),
+		ToolPolicy(OperationCreate),
+		testOptions(),
+	)
+	assertWaitError(t, err, "WAIT_PREEMPTED", "ISOLATED", OperationCreate)
+}
+
+func TestUnknownStatusKeepsPolling(t *testing.T) {
+	statuses := []string{"NEW_SERVER_STATE", "RUNNING"}
+	calls := 0
+	got, err := WaitForInstanceWithPolicy(
+		context.Background(),
+		"ins-1",
+		func(context.Context, string) (*ags.SandboxInstance, error) {
+			status := statuses[calls]
+			calls++
+			return &ags.SandboxInstance{Status: &status}, nil
+		},
+		InstancePolicy(OperationCreate),
+		testOptions(),
+	)
+	if err != nil || calls != 2 || got == nil || got.Status == nil || *got.Status != "RUNNING" {
+		t.Fatalf("calls = %d, instance = %#v, error = %v", calls, got, err)
 	}
 }
 
-func TestWaitForInstanceRejectsUnknownState(t *testing.T) {
+func TestUnknownStatusTimesOutWithDiagnostics(t *testing.T) {
 	status := "NEW_SERVER_STATE"
-	_, err := WaitForInstance(context.Background(), "ins-1", func(context.Context, string) (*ags.SandboxInstance, error) {
-		return &ags.SandboxInstance{Status: &status}, nil
-	}, testOptions())
+	_, err := WaitForInstanceWithPolicy(
+		context.Background(),
+		"ins-1",
+		instanceStatusGetter(status),
+		InstancePolicy(OperationCreate),
+		Options{Interval: time.Millisecond, Timeout: 5 * time.Millisecond},
+	)
 	var cliErr *output.CLIError
 	if !errors.As(err, &cliErr) {
 		t.Fatalf("error = %T %v, want *output.CLIError", err, err)
 	}
-	if cliErr.Failure.Code != "WAIT_UNKNOWN_STATUS" || cliErr.Failure.Kind != output.KindGenericError || cliErr.Failure.Details["LastStatus"] != status {
+	if cliErr.Failure.Code != "WAIT_TIMEOUT" || cliErr.Failure.Kind != output.KindTimeout {
 		t.Fatalf("failure = %#v", cliErr.Failure)
 	}
+	details := cliErr.Failure.Details
+	if details["LastStatus"] != status || details["Operation"] != string(OperationCreate) {
+		t.Fatalf("details = %#v", details)
+	}
+	attempts, ok := details["Attempts"].(int)
+	if !ok || attempts < 2 {
+		t.Fatalf("Attempts = %#v, want at least 2", details["Attempts"])
+	}
+	if _, ok := details["Elapsed"]; !ok {
+		t.Fatalf("details missing Elapsed: %#v", details)
+	}
+}
+
+func TestWaitForToolDeleteTreatsOnlyNotFoundAsSuccess(t *testing.T) {
+	t.Run("not found", func(t *testing.T) {
+		options := testOptions()
+		options.IsNotFound = isNotFoundError
+		got, err := WaitForToolWithPolicy(
+			context.Background(),
+			"tool-1",
+			func(context.Context, string) (*ags.SandboxTool, error) {
+				return nil, output.NewNotFoundError("TOOL_NOT_FOUND", "missing", "hint")
+			},
+			ToolPolicy(OperationDelete),
+			options,
+		)
+		if err != nil || got != nil {
+			t.Fatalf("tool = %#v, error = %v", got, err)
+		}
+	})
+
+	t.Run("other error", func(t *testing.T) {
+		options := testOptions()
+		options.IsNotFound = isNotFoundError
+		want := errors.New("network down")
+		_, err := WaitForToolWithPolicy(
+			context.Background(),
+			"tool-1",
+			func(context.Context, string) (*ags.SandboxTool, error) {
+				return nil, want
+			},
+			ToolPolicy(OperationDelete),
+			options,
+		)
+		if !errors.Is(err, want) {
+			t.Fatalf("error = %v, want %v", err, want)
+		}
+	})
 }
 
 func TestWaitStopsWhenParentContextIsCanceled(t *testing.T) {
@@ -185,6 +272,37 @@ func TestWaitStopsWhenParentContextIsCanceled(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("error = %v, want context.Canceled", err)
 	}
+}
+
+func instanceStatusGetter(status string) func(context.Context, string) (*ags.SandboxInstance, error) {
+	return func(context.Context, string) (*ags.SandboxInstance, error) {
+		return &ags.SandboxInstance{Status: &status}, nil
+	}
+}
+
+func toolStatusGetter(status string) func(context.Context, string) (*ags.SandboxTool, error) {
+	return func(context.Context, string) (*ags.SandboxTool, error) {
+		return &ags.SandboxTool{Status: &status}, nil
+	}
+}
+
+func assertWaitError(t *testing.T, err error, code, status string, operation Operation) {
+	t.Helper()
+	var cliErr *output.CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("error = %T %v, want *output.CLIError", err, err)
+	}
+	if cliErr.Failure.Code != code || cliErr.Failure.Details["LastStatus"] != status {
+		t.Fatalf("failure = %#v", cliErr.Failure)
+	}
+	if cliErr.Failure.Details["Operation"] != string(operation) {
+		t.Fatalf("operation details = %#v", cliErr.Failure.Details)
+	}
+}
+
+func isNotFoundError(err error) bool {
+	var cliErr *output.CLIError
+	return errors.As(err, &cliErr) && cliErr.Failure != nil && cliErr.Failure.Kind == output.KindNotFound
 }
 
 func testOptions() Options {

--- a/internal/commands/registry_generated_test.go
+++ b/internal/commands/registry_generated_test.go
@@ -1,6 +1,10 @@
 package commands
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
+)
 
 func TestRegistryIncludesAllKnownCommandModules(t *testing.T) {
 	registry, err := Registry()
@@ -49,4 +53,52 @@ func TestRegistryIncludesAllKnownCommandModules(t *testing.T) {
 	if got := len(registry.Modules()); got != len(want) {
 		t.Fatalf("module count = %d, want %d", got, len(want))
 	}
+}
+
+func TestWaitFlagScope(t *testing.T) {
+	registry, err := Registry()
+	if err != nil {
+		t.Fatalf("Registry returned error: %v", err)
+	}
+	wantWait := []string{
+		"instance.create",
+		"instance.get",
+		"instance.pause",
+		"instance.resume",
+		"instance.update",
+		"tool.create",
+		"tool.fork",
+		"tool.get",
+		"tool.update",
+	}
+	for _, id := range wantWait {
+		module, ok := registry.Lookup(id)
+		if !ok {
+			t.Fatalf("registry missing %s", id)
+		}
+		flag, ok := findFlag(module.Descriptor.Spec.Flags, "wait")
+		if !ok || flag.Type != command.FlagBool || !flag.Workflow {
+			t.Errorf("%s --wait = %#v, present = %v", id, flag, ok)
+		}
+		if module.Descriptor.Generated != nil {
+			if flag, ok := findFlag(module.Descriptor.Generated.Spec.Flags, "wait"); ok {
+				t.Errorf("%s generated API snapshot unexpectedly includes workflow --wait: %#v", id, flag)
+			}
+		}
+	}
+	for _, id := range []string{"instance.delete", "instance.list", "tool.delete", "tool.list"} {
+		module, _ := registry.Lookup(id)
+		if flag, ok := findFlag(module.Descriptor.Spec.Flags, "wait"); ok {
+			t.Errorf("%s unexpectedly exposes --wait: %#v", id, flag)
+		}
+	}
+}
+
+func findFlag(flags []command.FlagSpec, name string) (command.FlagSpec, bool) {
+	for _, flag := range flags {
+		if flag.Name == name {
+			return flag, true
+		}
+	}
+	return command.FlagSpec{}, false
 }

--- a/internal/commands/registry_generated_test.go
+++ b/internal/commands/registry_generated_test.go
@@ -62,11 +62,13 @@ func TestWaitFlagScope(t *testing.T) {
 	}
 	wantWait := []string{
 		"instance.create",
+		"instance.delete",
 		"instance.get",
 		"instance.pause",
 		"instance.resume",
 		"instance.update",
 		"tool.create",
+		"tool.delete",
 		"tool.fork",
 		"tool.get",
 		"tool.update",
@@ -86,7 +88,7 @@ func TestWaitFlagScope(t *testing.T) {
 			}
 		}
 	}
-	for _, id := range []string{"instance.delete", "instance.list", "tool.delete", "tool.list"} {
+	for _, id := range []string{"instance.list", "tool.list"} {
 		module, _ := registry.Lookup(id)
 		if flag, ok := findFlag(module.Descriptor.Spec.Flags, "wait"); ok {
 			t.Errorf("%s unexpectedly exposes --wait: %#v", id, flag)

--- a/internal/commands/tool/create/command.go
+++ b/internal/commands/tool/create/command.go
@@ -9,6 +9,8 @@ import (
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/apicli"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/cli"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/internal/resourcewait"
+	toolget "github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/tool/get"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/output"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/progress"
 	ags "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ags/v20250920"
@@ -17,12 +19,14 @@ import (
 // Module returns this package's command module.
 func Module() command.Module {
 	api := APIDescriptor()
-	spec := api.CommandSpec()
+	generatedSpec := api.CommandSpec()
+	spec := generatedSpec
+	spec.Flags = append(spec.Flags, resourcewait.Flag())
 	return command.Module{
 		Descriptor: command.Descriptor{
 			Spec: spec,
 			Generated: &command.Descriptor{
-				Spec:   spec,
+				Spec:   generatedSpec,
 				Groups: api.Groups,
 				API:    api,
 				Source: "apicli",
@@ -63,11 +67,35 @@ func Module() command.Module {
 						// Response type mismatch or missing ToolId — cannot confirm success.
 						sp.Cleanup()
 					}
+					if resourcewait.Requested(req) {
+						response, ok := result.Data.(*ags.CreateSandboxToolResponseParams)
+						if !ok || derefString(response.ToolId) == "" {
+							return nil, missingToolIDError()
+						}
+						getter, ok := deps.ControlPlane.(resourcewait.ToolGetter)
+						if !ok {
+							return nil, fmt.Errorf("tool.create --wait requires GetTool support")
+						}
+						tool, err := resourcewait.WaitForTool(ctx, derefString(response.ToolId), getter.GetTool, resourcewait.OptionsFromDeps(deps))
+						if err != nil {
+							return nil, err
+						}
+						return resourcewait.PreserveMutationMetadata(toolget.Result(tool), result), nil
+					}
 					return result, nil
 				}),
 			}, nil
 		},
 	}
+}
+
+func missingToolIDError() error {
+	return output.NewCLIError(&output.Failure{
+		Code:    "INTERNAL_ERROR",
+		Kind:    output.KindGenericError,
+		Message: "cannot wait because the create response did not include a tool id",
+		Hint:    "Rerun with --debug. If the issue persists, inspect the control-plane response.",
+	})
 }
 
 // applyCreateResultText enriches the command result with text rendering and

--- a/internal/commands/tool/create/command.go
+++ b/internal/commands/tool/create/command.go
@@ -76,7 +76,13 @@ func Module() command.Module {
 						if !ok {
 							return nil, fmt.Errorf("tool.create --wait requires GetTool support")
 						}
-						tool, err := resourcewait.WaitForTool(ctx, derefString(response.ToolId), getter.GetTool, resourcewait.OptionsFromDeps(deps))
+						tool, err := resourcewait.WaitForToolWithPolicy(
+							ctx,
+							derefString(response.ToolId),
+							getter.GetTool,
+							resourcewait.ToolPolicy(resourcewait.OperationCreate),
+							resourcewait.OptionsFromDeps(deps),
+						)
 						if err != nil {
 							return nil, err
 						}

--- a/internal/commands/tool/create/command_test.go
+++ b/internal/commands/tool/create/command_test.go
@@ -6,8 +6,10 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/internal/resourcewait"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/iostreams"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/output"
 	ags "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ags/v20250920"
@@ -16,18 +18,27 @@ import (
 // fakeMixedControlPlane implements apicli.ControlPlane for testing the full
 // tool create flow (validation → request build → executor → response render).
 type fakeMixedControlPlane struct {
-	action  string
-	request map[string]any
-	resp    *ags.CreateSandboxToolResponseParams
+	action    string
+	request   map[string]any
+	resp      *ags.CreateSandboxToolResponseParams
+	calls     int
+	getCalls  int
+	finalTool *ags.SandboxTool
 }
 
 func (f *fakeMixedControlPlane) Call(_ context.Context, action string, request map[string]any) (any, error) {
 	f.action = action
 	f.request = request
+	f.calls++
 	if f.resp != nil {
 		return f.resp, nil
 	}
 	return map[string]any{"ok": true}, nil
+}
+
+func (f *fakeMixedControlPlane) GetTool(_ context.Context, _ string) (*ags.SandboxTool, error) {
+	f.getCalls++
+	return f.finalTool, nil
 }
 
 // allToolCreateFlags returns a complete flag set mimicking what Cobra registers
@@ -224,6 +235,33 @@ func TestModuleCreatesToolAndRendersText(t *testing.T) {
 	}
 	if result.Effects[0].Kind != "create" || result.Effects[0].Resource != "tool" {
 		t.Fatalf("effect = %+v", result.Effects[0])
+	}
+}
+
+func TestModuleWaitsAfterCreatingExactlyOnce(t *testing.T) {
+	toolID := "sdt-new123"
+	active := "ACTIVE"
+	cp := &fakeMixedControlPlane{
+		resp:      &ags.CreateSandboxToolResponseParams{ToolId: &toolID},
+		finalTool: &ags.SandboxTool{ToolId: &toolID, Status: &active},
+	}
+	runtime, err := Module().Build(command.Deps{ControlPlane: cp, Values: map[string]any{
+		resourcewait.OptionsKey: resourcewait.Options{Interval: time.Millisecond, Timeout: 50 * time.Millisecond},
+	}})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	flags := minRequiredFlags()
+	flags["wait"] = command.FlagValue{Name: "wait", Type: command.FlagBool, Bool: true}
+	result, err := runtime.Handler.Run(context.Background(), command.Request{Flags: flags})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if cp.calls != 1 || cp.getCalls != 1 {
+		t.Fatalf("Call = %d, GetTool = %d", cp.calls, cp.getCalls)
+	}
+	if result.Data.(map[string]any)["Status"] != active || len(result.Effects) != 1 {
+		t.Fatalf("result = %#v", result)
 	}
 }
 

--- a/internal/commands/tool/create/command_test.go
+++ b/internal/commands/tool/create/command_test.go
@@ -265,6 +265,31 @@ func TestModuleWaitsAfterCreatingExactlyOnce(t *testing.T) {
 	}
 }
 
+func TestModuleWaitReportsNewToolIsolatedAsUnavailable(t *testing.T) {
+	toolID := "sdt-new123"
+	isolated := "ISOLATED"
+	cp := &fakeMixedControlPlane{
+		resp:      &ags.CreateSandboxToolResponseParams{ToolId: &toolID},
+		finalTool: &ags.SandboxTool{ToolId: &toolID, Status: &isolated},
+	}
+	runtime, err := Module().Build(command.Deps{ControlPlane: cp, Values: map[string]any{
+		resourcewait.OptionsKey: resourcewait.Options{Interval: time.Millisecond, Timeout: 50 * time.Millisecond},
+	}})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	flags := minRequiredFlags()
+	flags["wait"] = command.FlagValue{Name: "wait", Type: command.FlagBool, Bool: true}
+	_, err = runtime.Handler.Run(context.Background(), command.Request{Flags: flags})
+	var cliErr *output.CLIError
+	if !errors.As(err, &cliErr) || cliErr.Failure.Code != "WAIT_PREEMPTED" {
+		t.Fatalf("error = %#v, want WAIT_PREEMPTED", err)
+	}
+	if cp.calls != 1 || cp.getCalls != 1 {
+		t.Fatalf("Call = %d, GetTool = %d", cp.calls, cp.getCalls)
+	}
+}
+
 func TestModuleCreatesToolWithAllOptionalFlags(t *testing.T) {
 	toolID := "sdt-full"
 	cp := &fakeMixedControlPlane{resp: &ags.CreateSandboxToolResponseParams{

--- a/internal/commands/tool/delete/command.go
+++ b/internal/commands/tool/delete/command.go
@@ -9,6 +9,7 @@ import (
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/apicli"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/cli"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/internal/resourcewait"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/output"
 )
 
@@ -16,6 +17,12 @@ import (
 // workflow. It keeps multi-delete behavior testable without a full SDK client.
 type ControlPlane interface {
 	DeleteTool(ctx context.Context, toolID string) error
+}
+
+// NotFoundClassifier lets the delete waiter distinguish deletion completion
+// from other GetTool failures.
+type NotFoundClassifier interface {
+	IsNotFound(error) bool
 }
 
 // Summary aggregates per-tool delete outcomes for text and JSON rendering.
@@ -45,6 +52,7 @@ func Module() command.Module {
 		{Name: "tool-id", Required: true, Repeatable: true, Description: "Sandbox tool ID."},
 	}
 	spec.Flags = append(spec.Flags,
+		resourcewait.Flag(),
 		command.FlagSpec{
 			Name:     "dry-run",
 			Usage:    "List resources that would be deleted without actually executing the deletion",
@@ -89,7 +97,8 @@ func Module() command.Module {
 					dryRun := isDryRun(req)
 					skipConfirm := isYes(req)
 
-					// --request mode: single tool, error propagates directly.
+					requestMode := requestFlag(req)
+					var ids []string
 					if requestFlag(req) {
 						if len(req.Args) > 1 {
 							return nil, output.NewUsageError("REQUEST_FLAG_CONFLICT", "--request only supports a single tool id", "Use --request for one ToolId at a time, or pass multiple positional arguments without --request.")
@@ -102,16 +111,10 @@ func Module() command.Module {
 						if strings.TrimSpace(toolID) == "" {
 							return nil, output.NewUsageError("MISSING_REQUIRED_ARG", "missing tool id", "Provide <tool-id>.")
 						}
-						if dryRun {
-							return dryRunResult([]string{toolID}, deps.IO.ErrOut), nil
-						}
-						if err := cp.DeleteTool(ctx, toolID); err != nil {
-							return nil, err
-						}
-						return resultFromSummary(Summary{Deleted: 1, DeletedIDs: []string{toolID}}, nil, deps.IO.ErrOut), nil
+						ids = []string{toolID}
+					} else {
+						ids = req.Args
 					}
-
-					ids := req.Args
 
 					// --dry-run: preview only, no actual deletion.
 					if dryRun {
@@ -137,15 +140,63 @@ func Module() command.Module {
 					// Execute deletion.
 					summary := Summary{}
 					var warnings []string
+					waitRequested := resourcewait.Requested(req)
+					var getter resourcewait.ToolGetter
+					var classifier NotFoundClassifier
+					if waitRequested {
+						var ok bool
+						getter, ok = deps.ControlPlane.(resourcewait.ToolGetter)
+						if !ok {
+							return nil, fmt.Errorf("tool.delete --wait requires GetTool support")
+						}
+						classifier, ok = deps.ControlPlane.(NotFoundClassifier)
+						if !ok {
+							return nil, fmt.Errorf("tool.delete --wait requires not-found classification support")
+						}
+					}
+
+					acceptedIDs := make([]string, 0, len(ids))
 					for _, toolID := range ids {
 						if err := cp.DeleteTool(ctx, toolID); err != nil {
+							if requestMode {
+								return nil, err
+							}
 							summary.Failed++
 							summary.FailedIDs = append(summary.FailedIDs, toolID)
 							warnings = append(warnings, fmt.Sprintf("failed to delete %s: %v", toolID, err))
 							continue
 						}
+						if waitRequested {
+							acceptedIDs = append(acceptedIDs, toolID)
+							continue
+						}
 						summary.Deleted++
 						summary.DeletedIDs = append(summary.DeletedIDs, toolID)
+					}
+
+					if waitRequested {
+						options := resourcewait.OptionsFromDeps(deps)
+						options.IsNotFound = classifier.IsNotFound
+						for _, toolID := range acceptedIDs {
+							_, err := resourcewait.WaitForToolWithPolicy(
+								ctx,
+								toolID,
+								getter.GetTool,
+								resourcewait.ToolPolicy(resourcewait.OperationDelete),
+								options,
+							)
+							if err != nil {
+								if requestMode {
+									return nil, err
+								}
+								summary.Failed++
+								summary.FailedIDs = append(summary.FailedIDs, toolID)
+								warnings = append(warnings, fmt.Sprintf("failed waiting for %s to be deleted: %v", toolID, err))
+								continue
+							}
+							summary.Deleted++
+							summary.DeletedIDs = append(summary.DeletedIDs, toolID)
+						}
 					}
 					return resultFromSummary(summary, warnings, deps.IO.ErrOut), nil
 				}),

--- a/internal/commands/tool/delete/command_test.go
+++ b/internal/commands/tool/delete/command_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"slices"
 	"testing"
 
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
@@ -13,6 +14,14 @@ import (
 type fakeControlPlane struct {
 	deleted []string
 	fail    map[string]error
+}
+
+func TestModuleDoesNotExposeWaitFlag(t *testing.T) {
+	if slices.ContainsFunc(Module().Descriptor.Spec.Flags, func(flag command.FlagSpec) bool {
+		return flag.Name == "wait"
+	}) {
+		t.Fatalf("tool.delete must not expose --wait")
+	}
 }
 
 func (f *fakeControlPlane) DeleteTool(_ context.Context, toolID string) error {

--- a/internal/commands/tool/delete/command_test.go
+++ b/internal/commands/tool/delete/command_test.go
@@ -6,30 +6,63 @@ import (
 	"errors"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/internal/resourcewait"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/output"
+	ags "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ags/v20250920"
 )
 
 type fakeControlPlane struct {
-	deleted []string
-	fail    map[string]error
+	deleted       []string
+	fail          map[string]error
+	getErr        map[string]error
+	notFoundOnGet map[string]bool
+	events        []string
 }
 
-func TestModuleDoesNotExposeWaitFlag(t *testing.T) {
-	if slices.ContainsFunc(Module().Descriptor.Spec.Flags, func(flag command.FlagSpec) bool {
+func TestModuleExposesWorkflowWaitWithoutChangingGeneratedDescriptor(t *testing.T) {
+	module := Module()
+	if !slices.ContainsFunc(module.Descriptor.Spec.Flags, func(flag command.FlagSpec) bool {
 		return flag.Name == "wait"
 	}) {
-		t.Fatalf("tool.delete must not expose --wait")
+		t.Fatalf("tool.delete must expose workflow --wait")
+	}
+	if module.Descriptor.Generated == nil {
+		t.Fatal("mixed module missing generated descriptor")
+	}
+	if slices.ContainsFunc(module.Descriptor.Generated.Spec.Flags, func(flag command.FlagSpec) bool {
+		return flag.Name == "wait"
+	}) {
+		t.Fatalf("generated API descriptor must not include workflow --wait")
 	}
 }
 
 func (f *fakeControlPlane) DeleteTool(_ context.Context, toolID string) error {
+	f.events = append(f.events, "delete:"+toolID)
 	if err := f.fail[toolID]; err != nil {
 		return err
 	}
 	f.deleted = append(f.deleted, toolID)
 	return nil
+}
+
+func (f *fakeControlPlane) GetTool(_ context.Context, toolID string) (*ags.SandboxTool, error) {
+	f.events = append(f.events, "get:"+toolID)
+	if f.notFoundOnGet[toolID] {
+		return nil, output.NewNotFoundError("TOOL_NOT_FOUND", "missing", "hint")
+	}
+	if err := f.getErr[toolID]; err != nil {
+		return nil, err
+	}
+	status := "DELETING"
+	return &ags.SandboxTool{ToolId: &toolID, Status: &status}, nil
+}
+
+func (f *fakeControlPlane) IsNotFound(err error) bool {
+	var cliErr *output.CLIError
+	return errors.As(err, &cliErr) && cliErr.Failure != nil && cliErr.Failure.Kind == output.KindNotFound
 }
 
 func TestModuleDeletesMultipleTools(t *testing.T) {
@@ -239,6 +272,76 @@ func TestModuleYesSkipsConfirmation(t *testing.T) {
 	}
 	summary := result.Data.(map[string]any)
 	if summary["Deleted"] != 1 {
+		t.Fatalf("summary = %#v", summary)
+	}
+}
+
+func TestModuleWaitSubmitsAllDeletesBeforePollingForNotFound(t *testing.T) {
+	cp := &fakeControlPlane{notFoundOnGet: map[string]bool{
+		"sdt-a": true,
+		"sdt-b": true,
+	}}
+	runtime, err := Module().Build(command.Deps{
+		ControlPlane: cp,
+		Values: map[string]any{resourcewait.OptionsKey: resourcewait.Options{
+			Interval: time.Millisecond,
+			Timeout:  50 * time.Millisecond,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	result, err := runtime.Handler.Run(context.Background(), command.Request{
+		Args: []string{"sdt-a", "sdt-b"},
+		Flags: map[string]command.FlagValue{
+			"wait": {Name: "wait", Type: command.FlagBool, Bool: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	wantEvents := []string{"delete:sdt-a", "delete:sdt-b", "get:sdt-a", "get:sdt-b"}
+	if !slices.Equal(cp.events, wantEvents) {
+		t.Fatalf("events = %#v, want %#v", cp.events, wantEvents)
+	}
+	if len(cp.deleted) != 2 {
+		t.Fatalf("mutations = %#v, want exactly two", cp.deleted)
+	}
+	summary := result.Data.(map[string]any)
+	if summary["Deleted"] != 2 || summary["Failed"] != 0 {
+		t.Fatalf("summary = %#v", summary)
+	}
+}
+
+func TestModuleWaitDoesNotTreatOtherGetErrorsAsDeleted(t *testing.T) {
+	cp := &fakeControlPlane{getErr: map[string]error{"sdt-a": errors.New("network down")}}
+	runtime, err := Module().Build(command.Deps{
+		ControlPlane: cp,
+		Values: map[string]any{resourcewait.OptionsKey: resourcewait.Options{
+			Interval: time.Millisecond,
+			Timeout:  50 * time.Millisecond,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	result, err := runtime.Handler.Run(context.Background(), command.Request{
+		Args: []string{"sdt-a"},
+		Flags: map[string]command.FlagValue{
+			"wait": {Name: "wait", Type: command.FlagBool, Bool: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(cp.deleted) != 1 {
+		t.Fatalf("mutations = %#v, want exactly one", cp.deleted)
+	}
+	if result.ExitCode != output.ExitPartialSuccess || result.Failure == nil {
+		t.Fatalf("result = %#v", result)
+	}
+	summary := result.Data.(map[string]any)
+	if summary["Deleted"] != 0 || summary["Failed"] != 1 {
 		t.Fatalf("summary = %#v", summary)
 	}
 }

--- a/internal/commands/tool/fork/command.go
+++ b/internal/commands/tool/fork/command.go
@@ -8,7 +8,9 @@ import (
 
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/apicli"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/internal/resourcewait"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/internal/tooltags"
+	toolget "github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/tool/get"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/output"
 	ags "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ags/v20250920"
 )
@@ -23,6 +25,7 @@ type ControlPlane interface {
 func Module() command.Module {
 	api := forkAPIDescriptor()
 	spec := api.CommandSpec()
+	spec.Flags = append(spec.Flags, resourcewait.Flag())
 	for i := range spec.Flags {
 		if spec.Flags[i].Name == "tool-name" {
 			spec.Flags[i].Required = true
@@ -70,7 +73,24 @@ func Module() command.Module {
 					if err != nil {
 						return nil, err
 					}
-					return createResult(result, req), nil
+					mutationResult := createResult(result, req)
+					if !resourcewait.Requested(req) {
+						return mutationResult, nil
+					}
+					toolID := createdToolID(result)
+					if toolID == "" {
+						return nil, output.NewCLIError(&output.Failure{
+							Code:    "INTERNAL_ERROR",
+							Kind:    output.KindGenericError,
+							Message: "cannot wait because the create response did not include a tool id",
+							Hint:    "Rerun with --debug. If the issue persists, inspect the control-plane response.",
+						})
+					}
+					tool, err := resourcewait.WaitForTool(ctx, toolID, cp.GetTool, resourcewait.OptionsFromDeps(deps))
+					if err != nil {
+						return nil, err
+					}
+					return resourcewait.PreserveMutationMetadata(toolget.Result(tool), mutationResult), nil
 				}),
 			}, nil
 		},

--- a/internal/commands/tool/fork/command.go
+++ b/internal/commands/tool/fork/command.go
@@ -86,7 +86,13 @@ func Module() command.Module {
 							Hint:    "Rerun with --debug. If the issue persists, inspect the control-plane response.",
 						})
 					}
-					tool, err := resourcewait.WaitForTool(ctx, toolID, cp.GetTool, resourcewait.OptionsFromDeps(deps))
+					tool, err := resourcewait.WaitForToolWithPolicy(
+						ctx,
+						toolID,
+						cp.GetTool,
+						resourcewait.ToolPolicy(resourcewait.OperationFork),
+						resourcewait.OptionsFromDeps(deps),
+					)
 					if err != nil {
 						return nil, err
 					}

--- a/internal/commands/tool/fork/command_test.go
+++ b/internal/commands/tool/fork/command_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/apicli"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/internal/resourcewait"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/output"
 	ags "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ags/v20250920"
 )
@@ -17,11 +19,18 @@ type fakeControlPlane struct {
 	callErr    error
 	action     string
 	request    map[string]any
+	getIDs     []string
+	callCount  int
 }
 
 func (f *fakeControlPlane) GetTool(_ context.Context, toolID string) (*ags.SandboxTool, error) {
+	f.getIDs = append(f.getIDs, toolID)
 	if f.getErr != nil {
 		return nil, f.getErr
+	}
+	if toolID == "sdt-new" {
+		status := "ACTIVE"
+		return &ags.SandboxTool{ToolId: &toolID, Status: &status}, nil
 	}
 	if f.sourceTool != nil {
 		return f.sourceTool, nil
@@ -32,10 +41,37 @@ func (f *fakeControlPlane) GetTool(_ context.Context, toolID string) (*ags.Sandb
 func (f *fakeControlPlane) Call(_ context.Context, action string, request map[string]any) (any, error) {
 	f.action = action
 	f.request = request
+	f.callCount++
 	if f.callErr != nil {
 		return nil, f.callErr
 	}
 	return map[string]any{"ToolId": "sdt-new"}, nil
+}
+
+func TestModuleWaitsForForkedToolWithoutRepeatingCreate(t *testing.T) {
+	cp := &fakeControlPlane{}
+	runtime, err := Module().Build(command.Deps{ControlPlane: cp, Values: map[string]any{
+		resourcewait.OptionsKey: resourcewait.Options{Interval: time.Millisecond, Timeout: 50 * time.Millisecond},
+	}})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	result, err := runtime.Handler.Run(context.Background(), command.Request{
+		Args: []string{"sdt-source"},
+		Flags: map[string]command.FlagValue{
+			"tool-name": {Name: "tool-name", Type: command.FlagString, String: "copy", Changed: true},
+			"wait":      {Name: "wait", Type: command.FlagBool, Bool: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if cp.callCount != 1 || len(cp.getIDs) != 2 || cp.getIDs[0] != "sdt-source" || cp.getIDs[1] != "sdt-new" {
+		t.Fatalf("Call = %d, GetTool ids = %#v", cp.callCount, cp.getIDs)
+	}
+	if result.Data.(map[string]any)["Status"] != "ACTIVE" {
+		t.Fatalf("result = %#v", result.Data)
+	}
 }
 
 func TestModuleCopiesCreateCapableFields(t *testing.T) {

--- a/internal/commands/tool/fork/command_test.go
+++ b/internal/commands/tool/fork/command_test.go
@@ -15,6 +15,7 @@ import (
 
 type fakeControlPlane struct {
 	sourceTool *ags.SandboxTool
+	newStatus  string
 	getErr     error
 	callErr    error
 	action     string
@@ -29,7 +30,10 @@ func (f *fakeControlPlane) GetTool(_ context.Context, toolID string) (*ags.Sandb
 		return nil, f.getErr
 	}
 	if toolID == "sdt-new" {
-		status := "ACTIVE"
+		status := f.newStatus
+		if status == "" {
+			status = "ACTIVE"
+		}
 		return &ags.SandboxTool{ToolId: &toolID, Status: &status}, nil
 	}
 	if f.sourceTool != nil {
@@ -71,6 +75,30 @@ func TestModuleWaitsForForkedToolWithoutRepeatingCreate(t *testing.T) {
 	}
 	if result.Data.(map[string]any)["Status"] != "ACTIVE" {
 		t.Fatalf("result = %#v", result.Data)
+	}
+}
+
+func TestModuleWaitReportsForkedToolIsolatedAsUnavailable(t *testing.T) {
+	cp := &fakeControlPlane{newStatus: "ISOLATED"}
+	runtime, err := Module().Build(command.Deps{ControlPlane: cp, Values: map[string]any{
+		resourcewait.OptionsKey: resourcewait.Options{Interval: time.Millisecond, Timeout: 50 * time.Millisecond},
+	}})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	_, err = runtime.Handler.Run(context.Background(), command.Request{
+		Args: []string{"sdt-source"},
+		Flags: map[string]command.FlagValue{
+			"tool-name": {Name: "tool-name", Type: command.FlagString, String: "copy", Changed: true},
+			"wait":      {Name: "wait", Type: command.FlagBool, Bool: true},
+		},
+	})
+	var cliErr *output.CLIError
+	if !errors.As(err, &cliErr) || cliErr.Failure.Code != "WAIT_PREEMPTED" {
+		t.Fatalf("error = %#v, want WAIT_PREEMPTED", err)
+	}
+	if cp.callCount != 1 {
+		t.Fatalf("Call = %d, want exactly one create mutation", cp.callCount)
 	}
 }
 

--- a/internal/commands/tool/get/command.go
+++ b/internal/commands/tool/get/command.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/internal/resourcewait"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/output"
 	ags "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ags/v20250920"
 )
@@ -29,6 +30,7 @@ func Module() command.Module {
 		Args: []command.ArgSpec{
 			{Name: "tool-id", Required: true, Description: "Sandbox tool ID."},
 		},
+		Flags: []command.FlagSpec{resourcewait.Flag()},
 		Output: command.OutputSpec{
 			DataType:    "SandboxTool",
 			Description: "Sandbox tool details.",
@@ -63,18 +65,30 @@ func Module() command.Module {
 					if strings.TrimSpace(toolID) == "" {
 						return nil, output.NewUsageError("MISSING_REQUIRED_ARG", "missing tool id", "Provide <tool-id>.")
 					}
-					tool, err := cp.GetTool(ctx, toolID)
+					var tool *ags.SandboxTool
+					var err error
+					if resourcewait.Requested(req) {
+						tool, err = resourcewait.WaitForTool(ctx, toolID, cp.GetTool, resourcewait.OptionsFromDeps(deps))
+					} else {
+						tool, err = cp.GetTool(ctx, toolID)
+					}
 					if err != nil {
 						return nil, err
 					}
-					return &command.Result{
-						Data: canonicalToolData(tool),
-						Text: func(w io.Writer) {
-							renderToolDetails(w, tool)
-						},
-					}, nil
+					return Result(tool), nil
 				}),
 			}, nil
+		},
+	}
+}
+
+// Result returns the canonical command result for a Tool. Lifecycle mutation
+// commands reuse it after --wait reaches ACTIVE.
+func Result(tool *ags.SandboxTool) *command.Result {
+	return &command.Result{
+		Data: canonicalToolData(tool),
+		Text: func(w io.Writer) {
+			renderToolDetails(w, tool)
 		},
 	}
 }

--- a/internal/commands/tool/get/command.go
+++ b/internal/commands/tool/get/command.go
@@ -106,10 +106,14 @@ func renderToolDetails(w io.Writer, tool *ags.SandboxTool) {
 		{key: "ID", value: derefString(tool.ToolId)},
 		{key: "Name", value: derefString(tool.ToolName)},
 		{key: "Type", value: derefString(tool.ToolType)},
+		{key: "Status", value: derefString(tool.Status)},
 		{key: "NetworkMode", value: networkMode},
 		{key: "Description", value: derefString(tool.Description)},
 		{key: "Tags", value: tagsStr},
 		{key: "Created", value: formatShortTime(derefString(tool.CreateTime))},
+	}
+	if tool.StatusReason != nil && *tool.StatusReason != "" {
+		kvs = append(kvs, keyValue{key: "StatusReason", value: *tool.StatusReason})
 	}
 	if tool.RoleArn != nil && *tool.RoleArn != "" {
 		kvs = append(kvs, keyValue{key: "RoleArn", value: *tool.RoleArn})

--- a/internal/commands/tool/get/command_test.go
+++ b/internal/commands/tool/get/command_test.go
@@ -6,23 +6,78 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/internal/resourcewait"
 	ags "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ags/v20250920"
 )
 
 type fakeControlPlane struct {
 	toolID string
 	err    error
+	tools  []*ags.SandboxTool
+	calls  int
 }
 
 func (f *fakeControlPlane) GetTool(_ context.Context, toolID string) (*ags.SandboxTool, error) {
 	f.toolID = toolID
+	f.calls++
 	if f.err != nil {
 		return nil, f.err
 	}
+	if len(f.tools) > 0 {
+		index := f.calls - 1
+		if index >= len(f.tools) {
+			index = len(f.tools) - 1
+		}
+		return f.tools[index], nil
+	}
 	id := toolID
 	return &ags.SandboxTool{ToolId: &id}, nil
+}
+
+func TestModuleDescriptorIncludesWait(t *testing.T) {
+	for _, flag := range Module().Descriptor.Spec.Flags {
+		if flag.Name == "wait" && flag.Type == command.FlagBool && flag.Workflow {
+			return
+		}
+	}
+	t.Fatal("tool get descriptor does not include workflow --wait")
+}
+
+func TestModuleWaitsForToolTerminalState(t *testing.T) {
+	creating := "CREATING"
+	active := "ACTIVE"
+	cp := &fakeControlPlane{tools: []*ags.SandboxTool{
+		{Status: &creating},
+		{Status: &active},
+	}}
+	runtime, err := Module().Build(command.Deps{
+		ControlPlane: cp,
+		Values: map[string]any{resourcewait.OptionsKey: resourcewait.Options{
+			Interval: time.Millisecond,
+			Timeout:  50 * time.Millisecond,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+	result, err := runtime.Handler.Run(context.Background(), command.Request{
+		Args: []string{"sdt-unit"},
+		Flags: map[string]command.FlagValue{
+			"wait": {Name: "wait", Type: command.FlagBool, Bool: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if cp.calls != 2 {
+		t.Fatalf("GetTool calls = %d, want 2", cp.calls)
+	}
+	if result.Data.(map[string]any)["Status"] != active {
+		t.Fatalf("data = %#v", result.Data)
+	}
 }
 
 func TestModuleExecutesToolGetter(t *testing.T) {

--- a/internal/commands/tool/get/command_test.go
+++ b/internal/commands/tool/get/command_test.go
@@ -206,3 +206,21 @@ func TestRenderToolDetailsIncludesOptionalFields(t *testing.T) {
 		t.Fatalf("data = %#v", data)
 	}
 }
+
+func TestRenderToolDetailsIncludesFailedStatusReason(t *testing.T) {
+	status := "FAILED"
+	statusReason := "provider image pull failed"
+	tool := &ags.SandboxTool{
+		Status:       &status,
+		StatusReason: &statusReason,
+	}
+
+	var text bytes.Buffer
+	renderToolDetails(&text, tool)
+	got := text.String()
+	for _, want := range []string{"Status:", status, "StatusReason:", statusReason} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("text missing %q: %s", want, got)
+		}
+	}
+}

--- a/internal/commands/tool/update/command.go
+++ b/internal/commands/tool/update/command.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/apicli"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/internal/resourcewait"
+	toolget "github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/tool/get"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/output"
 	ags "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ags/v20250920"
 )
@@ -14,12 +16,14 @@ import (
 // Module returns this package's command module.
 func Module() command.Module {
 	api := APIDescriptor()
-	spec := api.CommandSpec()
+	generatedSpec := api.CommandSpec()
+	spec := generatedSpec
+	spec.Flags = append(spec.Flags, resourcewait.Flag())
 	return command.Module{
 		Descriptor: command.Descriptor{
 			Spec: spec,
 			Generated: &command.Descriptor{
-				Spec:   spec,
+				Spec:   generatedSpec,
 				Groups: api.Groups,
 				API:    api,
 				Source: "apicli",
@@ -45,6 +49,23 @@ func Module() command.Module {
 						return nil, err
 					}
 					applyUpdateResultText(result, req)
+					if resourcewait.Requested(req) {
+						getter, ok := deps.ControlPlane.(resourcewait.ToolGetter)
+						if !ok {
+							return nil, fmt.Errorf("tool.update --wait requires GetTool support")
+						}
+						toolID, err := ToolID(req)
+						if err != nil {
+							return nil, err
+						}
+						options := resourcewait.OptionsFromDeps(deps)
+						options.DelayBeforeFirstPoll = true
+						tool, err := resourcewait.WaitForTool(ctx, toolID, getter.GetTool, options)
+						if err != nil {
+							return nil, err
+						}
+						return resourcewait.PreserveMutationMetadata(toolget.Result(tool), result), nil
+					}
 					return result, nil
 				}),
 			}, nil

--- a/internal/commands/tool/update/command.go
+++ b/internal/commands/tool/update/command.go
@@ -58,9 +58,13 @@ func Module() command.Module {
 						if err != nil {
 							return nil, err
 						}
-						options := resourcewait.OptionsFromDeps(deps)
-						options.DelayBeforeFirstPoll = true
-						tool, err := resourcewait.WaitForTool(ctx, toolID, getter.GetTool, options)
+						tool, err := resourcewait.WaitForToolWithPolicy(
+							ctx,
+							toolID,
+							getter.GetTool,
+							resourcewait.ToolPolicy(resourcewait.OperationUpdate),
+							resourcewait.OptionsFromDeps(deps),
+						)
 						if err != nil {
 							return nil, err
 						}

--- a/internal/commands/tool/update/command_test.go
+++ b/internal/commands/tool/update/command_test.go
@@ -4,25 +4,75 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/apicli"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/internal/resourcewait"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/output"
+	ags "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ags/v20250920"
 )
 
 type fakeControlPlane struct {
-	action  string
-	request map[string]any
-	err     error
+	action         string
+	request        map[string]any
+	err            error
+	calls          int
+	getCalls       int
+	updateReturned time.Time
+	firstGet       time.Time
 }
 
 func (f *fakeControlPlane) Call(_ context.Context, action string, request map[string]any) (any, error) {
 	f.action = action
 	f.request = request
+	f.calls++
 	if f.err != nil {
 		return nil, f.err
 	}
+	f.updateReturned = time.Now()
 	return map[string]any{"ok": true}, nil
+}
+
+func (f *fakeControlPlane) GetTool(_ context.Context, toolID string) (*ags.SandboxTool, error) {
+	f.getCalls++
+	if f.firstGet.IsZero() {
+		f.firstGet = time.Now()
+	}
+	status := "ACTIVE"
+	return &ags.SandboxTool{ToolId: &toolID, Status: &status}, nil
+}
+
+func TestModuleWaitsAfterUpdatingExactlyOnce(t *testing.T) {
+	const interval = 20 * time.Millisecond
+	cp := &fakeControlPlane{}
+	runtime, err := Module().Build(command.Deps{ControlPlane: cp, Values: map[string]any{
+		resourcewait.OptionsKey: resourcewait.Options{Interval: interval, Timeout: 100 * time.Millisecond},
+	}})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	result, err := runtime.Handler.Run(context.Background(), command.Request{
+		Args:      []string{"sdt-unit"},
+		ArgValues: map[string]string{"tool-id": "sdt-unit"},
+		Flags: map[string]command.FlagValue{
+			"description": {Name: "description", Type: command.FlagString, String: "updated", Changed: true},
+			"request":     {Name: "request", Type: command.FlagString},
+			"wait":        {Name: "wait", Type: command.FlagBool, Bool: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if cp.calls != 1 || cp.getCalls != 1 {
+		t.Fatalf("Call = %d, GetTool = %d", cp.calls, cp.getCalls)
+	}
+	if elapsed := cp.firstGet.Sub(cp.updateReturned); elapsed < interval {
+		t.Fatalf("first GetTool started %s after update returned, want at least %s", elapsed, interval)
+	}
+	if result.Data.(map[string]any)["Status"] != "ACTIVE" {
+		t.Fatalf("result = %#v", result.Data)
+	}
 }
 
 func TestModuleBuildsUpdateRequest(t *testing.T) {

--- a/internal/commands/tool/update/command_test.go
+++ b/internal/commands/tool/update/command_test.go
@@ -14,13 +14,11 @@ import (
 )
 
 type fakeControlPlane struct {
-	action         string
-	request        map[string]any
-	err            error
-	calls          int
-	getCalls       int
-	updateReturned time.Time
-	firstGet       time.Time
+	action   string
+	request  map[string]any
+	err      error
+	calls    int
+	getCalls int
 }
 
 func (f *fakeControlPlane) Call(_ context.Context, action string, request map[string]any) (any, error) {
@@ -30,24 +28,19 @@ func (f *fakeControlPlane) Call(_ context.Context, action string, request map[st
 	if f.err != nil {
 		return nil, f.err
 	}
-	f.updateReturned = time.Now()
 	return map[string]any{"ok": true}, nil
 }
 
 func (f *fakeControlPlane) GetTool(_ context.Context, toolID string) (*ags.SandboxTool, error) {
 	f.getCalls++
-	if f.firstGet.IsZero() {
-		f.firstGet = time.Now()
-	}
 	status := "ACTIVE"
 	return &ags.SandboxTool{ToolId: &toolID, Status: &status}, nil
 }
 
 func TestModuleWaitsAfterUpdatingExactlyOnce(t *testing.T) {
-	const interval = 20 * time.Millisecond
 	cp := &fakeControlPlane{}
 	runtime, err := Module().Build(command.Deps{ControlPlane: cp, Values: map[string]any{
-		resourcewait.OptionsKey: resourcewait.Options{Interval: interval, Timeout: 100 * time.Millisecond},
+		resourcewait.OptionsKey: resourcewait.Options{Interval: 50 * time.Millisecond, Timeout: 10 * time.Millisecond},
 	}})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
@@ -66,9 +59,6 @@ func TestModuleWaitsAfterUpdatingExactlyOnce(t *testing.T) {
 	}
 	if cp.calls != 1 || cp.getCalls != 1 {
 		t.Fatalf("Call = %d, GetTool = %d", cp.calls, cp.getCalls)
-	}
-	if elapsed := cp.firstGet.Sub(cp.updateReturned); elapsed < interval {
-		t.Fatalf("first GetTool started %s after update returned, want at least %s", elapsed, interval)
 	}
 	if result.Data.(map[string]any)["Status"] != "ACTIVE" {
 		t.Fatalf("result = %#v", result.Data)

--- a/tests/lifecycle/helpers_test.go
+++ b/tests/lifecycle/helpers_test.go
@@ -6,19 +6,34 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 
 	"github.com/TencentCloudAgentRuntime/ags-cli/tests/testutil"
 )
 
+const lifecycleCommandTimeout = 12 * time.Minute
+
 func newCLI() *testutil.CLI {
 	cli := testutil.NewCLI()
+	if cli.Timeout < lifecycleCommandTimeout {
+		cli.Timeout = lifecycleCommandTimeout
+	}
 	DeferCleanup(cli.Cleanup)
 	return cli
 }
 
 func stringField(data map[string]any, key string) string {
 	return testutil.StringField(data, key)
+}
+
+func createdResourceID(env testutil.Envelope, dataKey string) string {
+	if id, ok := env.Data[dataKey].(string); ok && id != "" {
+		return id
+	}
+	if env.Failure == nil {
+		return ""
+	}
+	id, _ := env.Failure.Details["ResourceId"].(string)
+	return id
 }
 
 func numberField(data map[string]any, key string) int {
@@ -80,34 +95,6 @@ func removeString(values []string, target string) []string {
 		}
 	}
 	return out
-}
-
-func waitForToolStatus(cli *testutil.CLI, toolID string, allowed ...string) testutil.Envelope {
-	var last testutil.CommandResult
-	var env testutil.Envelope
-	Eventually(func(g Gomega) string {
-		last = cli.Run(context.Background(), "--output", "json", "tool", "get", toolID)
-		g.Expect(last.ExitCode).To(Equal(0), last.Diagnostics())
-		env = last.Envelope()
-		return stringField(env.Data, "Status")
-	}, 8*time.Minute, 10*time.Second).Should(BeElementOf(allowed), func() string {
-		return fmt.Sprintf("tool %s did not reach %v\n%s", toolID, allowed, last.Diagnostics())
-	})
-	return env
-}
-
-func waitForInstanceStatus(cli *testutil.CLI, instanceID string, allowed ...string) testutil.Envelope {
-	var last testutil.CommandResult
-	var env testutil.Envelope
-	Eventually(func(g Gomega) string {
-		last = cli.Run(context.Background(), "--output", "json", "instance", "get", instanceID)
-		g.Expect(last.ExitCode).To(Equal(0), last.Diagnostics())
-		env = last.Envelope()
-		return stringField(env.Data, "Status")
-	}, 8*time.Minute, 10*time.Second).Should(BeElementOf(allowed), func() string {
-		return fmt.Sprintf("instance %s did not reach %v\n%s", instanceID, allowed, last.Diagnostics())
-	})
-	return env
 }
 
 func uniqueName(prefix string) string {

--- a/tests/lifecycle/helpers_unit_test.go
+++ b/tests/lifecycle/helpers_unit_test.go
@@ -1,0 +1,47 @@
+package lifecycle
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/TencentCloudAgentRuntime/ags-cli/tests/testutil"
+)
+
+func TestCreatedResourceID(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		dataKey string
+		want    string
+	}{
+		{
+			name:    "success data",
+			payload: `{"Data":{"ToolId":"tool-1"}}`,
+			dataKey: "ToolId",
+			want:    "tool-1",
+		},
+		{
+			name:    "wait failure details",
+			payload: `{"Failure":{"Details":{"ResourceId":"tool-2"}}}`,
+			dataKey: "ToolId",
+			want:    "tool-2",
+		},
+		{
+			name:    "failure without resource ID",
+			payload: `{"Failure":{"Code":"INVALID_ARGUMENT"}}`,
+			dataKey: "ToolId",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var env testutil.Envelope
+			if err := json.Unmarshal([]byte(tt.payload), &env); err != nil {
+				t.Fatalf("unmarshal envelope: %v", err)
+			}
+			if got := createdResourceID(env, tt.dataKey); got != tt.want {
+				t.Fatalf("createdResourceID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/tests/lifecycle/instance_lifecycle_test.go
+++ b/tests/lifecycle/instance_lifecycle_test.go
@@ -22,19 +22,29 @@ var _ = Describe("Instance CLI lifecycle", func() {
 
 	It("creates, inspects, lists, exercises data plane, and deletes an instance", func() {
 		toolID := testutil.State().EnsureToolID(context.Background())
-		args := []string{"--output", "json", "instance", "create", "--timeout", "5m", "--tool-id", toolID}
+		args := []string{"--output", "json", "instance", "create", "--wait", "--timeout", "5m", "--tool-id", toolID}
 
 		create := cli.Run(context.Background(), args...)
-		create.ExpectSuccess()
 		createEnv := create.Envelope()
+		instanceID := createdResourceID(createEnv, "InstanceId")
+		tracker.AddInstance(instanceID)
+		create.ExpectSuccess()
 		Expect(createEnv.Command).To(Equal("instance.create"))
 		Expect(createEnv.Status).To(Equal("succeeded"))
-		instanceID := stringField(createEnv.Data, "InstanceId")
 		Expect(instanceID).NotTo(BeEmpty())
-		tracker.AddInstance(instanceID)
+		Expect(stringField(createEnv.Data, "Status")).To(Equal("RUNNING"))
 
-		getEnv := waitForInstanceStatus(cli, instanceID, "RUNNING")
-		Expect(stringField(getEnv.Data, "InstanceId")).To(Equal(instanceID))
+		pause := cli.Run(context.Background(), "--output", "json", "instance", "pause", instanceID, "--wait")
+		pause.ExpectSuccess()
+		pauseEnv := pause.Envelope()
+		Expect(pauseEnv.Command).To(Equal("instance.pause"))
+		Expect(stringField(pauseEnv.Data, "Status")).To(Equal("PAUSED"))
+
+		resume := cli.Run(context.Background(), "--output", "json", "instance", "resume", instanceID, "--wait")
+		resume.ExpectSuccess()
+		resumeEnv := resume.Envelope()
+		Expect(resumeEnv.Command).To(Equal("instance.resume"))
+		Expect(stringField(resumeEnv.Data, "Status")).To(Equal("RUNNING"))
 
 		list := cli.Run(context.Background(), "--output", "json", "instance", "list", "--limit", "20")
 		list.ExpectSuccess()
@@ -58,7 +68,7 @@ var _ = Describe("Instance CLI lifecycle", func() {
 		remoteFailure.ExpectExit(7)
 		Expect(strings.TrimSpace(remoteFailure.Stdout)).To(BeEmpty(), remoteFailure.Diagnostics())
 
-		deleted := cli.Run(context.Background(), "--output", "json", "instance", "delete", instanceID)
+		deleted := cli.Run(context.Background(), "--output", "json", "instance", "delete", instanceID, "--wait")
 		deleted.ExpectSuccess()
 		deletedEnv := deleted.Envelope()
 		Expect(numberField(deletedEnv.Data, "Deleted")).To(Equal(1))

--- a/tests/lifecycle/tool_lifecycle_test.go
+++ b/tests/lifecycle/tool_lifecycle_test.go
@@ -30,6 +30,7 @@ var _ = Describe("Tool CLI lifecycle", func() {
 
 		toolName := uniqueName("ags-cli-e2e-tool")
 		create := cli.Run(context.Background(), "--output", "json", "tool", "create",
+			"--wait",
 			"-n", toolName,
 			"-t", "code-interpreter",
 			"-d", "AGR CLI E2E tool",
@@ -37,17 +38,17 @@ var _ = Describe("Tool CLI lifecycle", func() {
 			"--network-configuration", `{"NetworkMode":"PUBLIC"}`,
 			"--tags", `[{"Key":"ags-cli-e2e","Value":"true"}]`,
 		)
-		create.ExpectSuccess()
 		createEnv := create.Envelope()
+		toolID := createdResourceID(createEnv, "ToolId")
+		tracker.AddTool(toolID)
+		create.ExpectSuccess()
 		Expect(createEnv.Command).To(Equal("tool.create"))
 		Expect(createEnv.Status).To(Equal("succeeded"))
-		toolID := stringField(createEnv.Data, "ToolId")
 		Expect(toolID).NotTo(BeEmpty())
-		tracker.AddTool(toolID)
+		Expect(stringField(createEnv.Data, "Status")).To(Equal("ACTIVE"))
 
-		getEnv := waitForToolStatus(cli, toolID, "ACTIVE")
-		Expect(stringField(getEnv.Data, "ToolName")).To(Equal(toolName))
-		Expect(stringField(getEnv.Data, "ToolType")).To(Equal("code-interpreter"))
+		Expect(stringField(createEnv.Data, "ToolName")).To(Equal(toolName))
+		Expect(stringField(createEnv.Data, "ToolType")).To(Equal("code-interpreter"))
 
 		jq := cli.Run(context.Background(), "--output", "json", "--jq", ".Data.ToolId", "tool", "get", toolID)
 		jq.ExpectSuccess()
@@ -67,7 +68,7 @@ var _ = Describe("Tool CLI lifecycle", func() {
 		Expect(missingEnv.Failure).NotTo(BeNil())
 		Expect(missingEnv.Failure.Kind).To(Equal("not_found"))
 
-		deleted := cli.Run(context.Background(), "--output", "json", "tool", "delete", toolID)
+		deleted := cli.Run(context.Background(), "--output", "json", "tool", "delete", toolID, "--wait", "--yes")
 		deleted.ExpectSuccess()
 		deletedEnv := deleted.Envelope()
 		Expect(numberField(deletedEnv.Data, "Deleted")).To(Equal(1))

--- a/tests/testutil/cli.go
+++ b/tests/testutil/cli.go
@@ -51,10 +51,11 @@ type Envelope struct {
 
 // Failure mirrors the structured failure object inside an envelope.
 type Failure struct {
-	Code    string `json:"Code"`
-	Kind    string `json:"Kind"`
-	Message string `json:"Message"`
-	Hint    string `json:"Hint"`
+	Code    string         `json:"Code"`
+	Kind    string         `json:"Kind"`
+	Message string         `json:"Message"`
+	Hint    string         `json:"Hint"`
+	Details map[string]any `json:"Details"`
 }
 
 // NewCLI creates an isolated CLI runner using the suite's built binary.


### PR DESCRIPTION
## Summary

- add a shared stable-state waiter for Instance and Tool lifecycle commands
- expose `--wait` on Instance create/get/pause/resume/update and Tool create/fork/get/update
- poll explicit transitional states every 5 seconds with a 10-minute timeout, returning the final GET resource once a known stable state is reached
- reject unknown statuses with `WAIT_UNKNOWN_STATUS` and preserve mutation response metadata

## State handling

- Instance transitional states: `STARTING`, `PAUSING`, `STOPPING`
- Instance stable states: `RUNNING`, `PAUSED`, `STOPPED`, `FAILED`, `STARTING_FAILED`, `STOPPING_FAILED`, `PAUSE_FAILED`, `RESUME_FAILED`
- Tool transitional states: `CREATING`, `DELETING`
- Tool stable states: `ACTIVE`, `FAILED`, `ISOLATED`

Failure-like stable states are returned as the settled resource. `--wait` indicates that the resource has left a transitional state; it does not reinterpret the backend lifecycle result.

Delete and list commands intentionally do not expose `--wait`. For delete, the command does not have a final resource to return consistently after deletion.

## Validation

- `env GOCACHE=/private/tmp/ags-cli-gocache go test ./...`
- command help and generated-schema characterization tests cover where `--wait` is exposed and excluded

Closes #72
