### PR TITLE
fix(install): support non-root environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,17 @@ jobs:
       - name: Run tests
         run: go test -v -race -coverprofile=coverage.out ./...
 
+      - name: Test one-line installer
+        run: |
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            system_bin_mode="$(stat -c '%a' /usr/local/bin)"
+            trap 'sudo chmod "$system_bin_mode" /usr/local/bin' EXIT
+            sudo chmod a-w /usr/local/bin
+            sh scripts/test-install.sh --require-fallback
+          else
+            sh scripts/test-install.sh
+          fi
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/README-zh.md
+++ b/README-zh.md
@@ -20,6 +20,16 @@ brew install TencentCloudAgentRuntime/tap/agr-cli
 curl -fsSL https://dl.tencentags.com/agr-cli/latest/install.sh | sh
 ```
 
+安装器会优先使用可写的 `/usr/local/bin`；在无 root 权限的环境中，会自动回退到
+`$HOME/.local/bin`，且不会调用 `sudo`。如果所选目录不在 `PATH` 中，安装器会输出
+相应的添加命令。
+
+如需明确指定其他可写目录：
+
+```bash
+curl -fsSL https://dl.tencentags.com/agr-cli/latest/install.sh | INSTALL_DIR="$HOME/bin" sh
+```
+
 安装指定版本：
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -18,6 +18,17 @@ brew install TencentCloudAgentRuntime/tap/agr-cli
 curl -fsSL https://dl.tencentags.com/agr-cli/latest/install.sh | sh
 ```
 
+The installer uses `/usr/local/bin` when it is writable. In non-root
+environments it falls back to `$HOME/.local/bin` without invoking `sudo`. If
+the selected directory is not in `PATH`, the installer prints the command
+needed to add it.
+
+To choose another writable directory explicitly:
+
+```bash
+curl -fsSL https://dl.tencentags.com/agr-cli/latest/install.sh | INSTALL_DIR="$HOME/bin" sh
+```
+
 To install a specific version:
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -7,9 +7,20 @@ set -eu
 
 REPO="TencentCloudAgentRuntime/ags-cli"
 BINARY="agr"
-INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 AGR_DOWNLOAD_MIRROR="${AGR_DOWNLOAD_MIRROR:-official}"
 OFFICIAL_BASE_URL="${AGR_DOWNLOAD_BASE_URL:-https://dl.tencentags.com/agr-cli}"
+
+if [ -n "${INSTALL_DIR:-}" ]; then
+    : # Honor the caller's explicit install directory.
+elif [ -w /usr/local/bin ]; then
+    INSTALL_DIR="/usr/local/bin"
+elif [ -n "${HOME:-}" ]; then
+    INSTALL_DIR="${HOME}/.local/bin"
+else
+    echo "Error: no writable install directory found and HOME is not set." >&2
+    echo "Set INSTALL_DIR to a writable directory and retry." >&2
+    exit 1
+fi
 
 download() {
     url="$1"
@@ -155,16 +166,26 @@ fi
 
 chmod +x "$TMPDIR/$BIN_NAME"
 
-if [ -w "$INSTALL_DIR" ]; then
-    mv "$TMPDIR/$BIN_NAME" "${INSTALL_DIR}/${BINARY}"
-else
-    echo "Installing to ${INSTALL_DIR}/${BINARY} (requires sudo) ..."
-    sudo mv "$TMPDIR/$BIN_NAME" "${INSTALL_DIR}/${BINARY}"
+mkdir -p "$INSTALL_DIR"
+if [ ! -w "$INSTALL_DIR" ]; then
+    echo "Error: install directory '$INSTALL_DIR' is not writable." >&2
+    echo "Set INSTALL_DIR to a writable directory and retry." >&2
+    exit 1
 fi
+mv "$TMPDIR/$BIN_NAME" "${INSTALL_DIR}/${BINARY}"
 
 echo ""
 echo "AGR CLI installed successfully!"
 echo "  Command:  ${INSTALL_DIR}/${BINARY}"
-echo "  Version:  $(${INSTALL_DIR}/${BINARY} version 2>/dev/null | head -1 || echo "${TAG}")"
+echo "  Version:  $("${INSTALL_DIR}/${BINARY}" version 2>/dev/null | head -1 || echo "${TAG}")"
 echo ""
+case ":${PATH:-}:" in
+    *":${INSTALL_DIR}:"*) ;;
+    *)
+        echo "Note: ${INSTALL_DIR} is not in PATH."
+        echo "Add it for the current shell with:"
+        echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+        echo ""
+        ;;
+esac
 echo "Next step: run 'agr init' to configure your credentials."

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env sh
+set -eu
+
+REPO_ROOT="$(unset CDPATH; cd -- "$(dirname "$0")/.." && pwd)"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+case "${1:-}" in
+    "")                 require_fallback=false ;;
+    --require-fallback) require_fallback=true ;;
+    *)                  fail "unknown argument: $1" ;;
+esac
+
+assert_contains() {
+    file="$1"
+    expected="$2"
+    grep -F "$expected" "$file" >/dev/null 2>&1 || {
+        echo "Expected output to contain: $expected" >&2
+        cat "$file" >&2
+        fail "missing expected output"
+    }
+}
+
+assert_not_contains() {
+    file="$1"
+    unexpected="$2"
+    if grep -F "$unexpected" "$file" >/dev/null 2>&1; then
+        echo "Expected output not to contain: $unexpected" >&2
+        cat "$file" >&2
+        fail "found unexpected output"
+    fi
+}
+
+case "$(uname -s)" in
+    Linux)  os="linux" ;;
+    Darwin) os="darwin" ;;
+    *)      fail "unsupported test OS" ;;
+esac
+
+case "$(uname -m)" in
+    x86_64|amd64)  arch="amd64" ;;
+    aarch64|arm64) arch="arm64" ;;
+    *)             fail "unsupported test architecture" ;;
+esac
+
+version="0.0.0-test"
+tag="v${version}"
+filename="agr-${version}-${os}-${arch}.tar.gz"
+mirror_root="${TEST_ROOT}/mirror"
+release_dir="${mirror_root}/${tag}"
+payload_dir="${TEST_ROOT}/payload"
+fake_bin_dir="${TEST_ROOT}/fake-bin"
+
+mkdir -p "$release_dir" "$payload_dir" "$fake_bin_dir"
+
+cat >"${payload_dir}/agr" <<'EOF'
+#!/usr/bin/env sh
+if [ "${1:-}" = "version" ]; then
+    echo "agr version v0.0.0-test"
+fi
+EOF
+chmod +x "${payload_dir}/agr"
+tar -czf "${release_dir}/${filename}" -C "$payload_dir" agr
+
+if command -v shasum >/dev/null 2>&1; then
+    checksum="$(shasum -a 256 "${release_dir}/${filename}" | awk '{print $1}')"
+elif command -v sha256sum >/dev/null 2>&1; then
+    checksum="$(sha256sum "${release_dir}/${filename}" | awk '{print $1}')"
+else
+    fail "shasum or sha256sum is required"
+fi
+printf '%s  %s\n' "$checksum" "$filename" >"${release_dir}/checksums.txt"
+
+cat >"${fake_bin_dir}/sudo" <<'EOF'
+#!/usr/bin/env sh
+echo "unexpected sudo invocation" >&2
+exit 99
+EOF
+chmod +x "${fake_bin_dir}/sudo"
+
+run_installer() {
+    test_home="$1"
+    output_file="$2"
+    install_dir="${3:-}"
+    install_path="${4:-${fake_bin_dir}:${PATH}}"
+
+    if [ -n "$install_dir" ]; then
+        env \
+            HOME="$test_home" \
+            PATH="$install_path" \
+            VERSION="$tag" \
+            AGR_DOWNLOAD_BASE_URL="file://${mirror_root}" \
+            INSTALL_DIR="$install_dir" \
+            sh "${REPO_ROOT}/install.sh" >"$output_file" 2>&1
+    else
+        env -u INSTALL_DIR \
+            HOME="$test_home" \
+            PATH="$install_path" \
+            VERSION="$tag" \
+            AGR_DOWNLOAD_BASE_URL="file://${mirror_root}" \
+            sh "${REPO_ROOT}/install.sh" >"$output_file" 2>&1
+    fi
+}
+
+explicit_home="${TEST_ROOT}/explicit-home"
+explicit_dir="${explicit_home}/custom/bin"
+explicit_output="${TEST_ROOT}/explicit.out"
+mkdir -p "$explicit_home"
+
+if ! run_installer "$explicit_home" "$explicit_output" "$explicit_dir"; then
+    cat "$explicit_output" >&2
+    fail "explicit INSTALL_DIR installation failed"
+fi
+[ -x "${explicit_dir}/agr" ] || fail "explicit INSTALL_DIR binary is missing"
+assert_contains "$explicit_output" "Command:  ${explicit_dir}/agr"
+assert_contains "$explicit_output" "not in PATH"
+echo "PASS: explicit INSTALL_DIR is created without sudo"
+
+if [ -w /usr/local/bin ]; then
+    if [ "$require_fallback" = true ]; then
+        fail "fallback coverage required, but /usr/local/bin is writable"
+    fi
+    echo "SKIP: default fallback test (/usr/local/bin is writable)"
+else
+    fallback_home="${TEST_ROOT}/fallback-home"
+    fallback_dir="${fallback_home}/.local/bin"
+    fallback_output="${TEST_ROOT}/fallback.out"
+    fallback_path="${fallback_dir}:${fake_bin_dir}:${PATH}"
+    mkdir -p "$fallback_home"
+
+    if ! run_installer "$fallback_home" "$fallback_output" "" "$fallback_path"; then
+        cat "$fallback_output" >&2
+        fail "default user-local fallback installation failed"
+    fi
+    [ -x "${fallback_dir}/agr" ] || fail "fallback binary is missing"
+    assert_contains "$fallback_output" "Command:  ${fallback_dir}/agr"
+    assert_not_contains "$fallback_output" "not in PATH"
+    fallback_version="$(env PATH="$fallback_path" agr version)"
+    [ "$fallback_version" = "agr version v0.0.0-test" ] || fail "fallback binary is not executable through PATH"
+    echo "PASS: unwritable system directory falls back without sudo and is executable through PATH"
+fi


### PR DESCRIPTION
## Summary

- honor an explicit `INSTALL_DIR`
- use `/usr/local/bin` when it is writable, otherwise fall back to `$HOME/.local/bin`
- create the selected directory and never invoke `sudo` implicitly
- print an actionable `PATH` hint when the selected directory is not already available
- add installer behavior coverage on Linux and macOS and document the behavior in both READMEs

## Root cause

The installer defaulted to `/usr/local/bin` and treated any non-writable or not-yet-created destination as requiring `sudo`. This fails in non-root environments where `sudo` is unavailable, even when a standard user-writable binary directory exists.

## Verification

- `sh scripts/test-install.sh`
- `shellcheck install.sh scripts/test-install.sh`
- `actionlint -color`
- `go test ./cmd/... ./internal/...`
- `bash scripts/changelog.sh validate`
- `git diff --check`

### Tencent CloudShell (live)

Validated the PR head `d8ad58e` directly in Tencent CloudShell on 2026-08-04:

- CloudShell ran as the non-root user `uid=1000(cloudshell)`
- `/usr/local/bin` was not writable (`test -w /usr/local/bin` exited with `1`)
- `$HOME/.local/bin` was already present in `PATH`, matching the existing `tccli` installation layout
- the installer completed without `sudo` and installed AGR CLI to `/home/cloudshell/.local/bin/agr`
- a fresh login shell resolved `agr` to that path, and `agr version` reported `0.6.3`

The exact installer tested was fetched from commit `d8ad58ea138a5c0e61f62d8e1e63850770ac94ea`.

The locally configured live AGR smoke suites were also attempted, but the remote service returned `InternalError` across unrelated API and instance operations. The installer tests and isolated unit suites pass.

Fixes #86
