### PR TITLE
fix(schema): correct Mutation/RequiresAuth derivation and add missing 'custom' enum value

### DIFF
--- a/internal/apicli/executor.go
+++ b/internal/apicli/executor.go
@@ -62,7 +62,7 @@ func NewModule(desc APIDescriptor) command.Module {
 			Spec:   spec,
 			Groups: desc.Groups,
 			API:    desc,
-			Source: "apicli",
+			Source: command.SourceAPICli,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/cli/schema.go
+++ b/internal/cli/schema.go
@@ -406,6 +406,11 @@ func registeredSchemaSeeds() []CommandSchema {
 func schemaFromDescriptor(desc command.Descriptor) CommandSchema {
 	spec := desc.Spec
 	mutation, createsResource, requiresAuth := schemaEffects(spec.Output.Effects)
+	// Workflow commands always require authentication since they call the
+	// cloud control plane, even if they have no declared side-effects.
+	if desc.Source == command.SourceWorkflow {
+		requiresAuth = true
+	}
 	return CommandSchema{
 		Name:            spec.ID,
 		Kind:            "command",
@@ -438,6 +443,8 @@ func schemaEffects(effects []string) (mutation, createsResource, requiresAuth bo
 		case "create":
 			mutation = true
 			createsResource = true
+		case "update":
+			mutation = true
 		case "delete":
 			mutation = true
 		}
@@ -1297,7 +1304,7 @@ func buildHandwrittenSchemas() []CommandSchema {
 			SupportsRequest: true,
 			RequestSchema: &RequestSchema{Type: "object", AdditionalProperties: false, Required: []string{"Image"}, Properties: map[string]PropertySchema{
 				"Image":             {Type: "string", CliFlag: nil},
-				"ImageRegistryType": {Type: "enum", Values: []string{"enterprise", "personal"}, CliFlag: nil},
+				"ImageRegistryType": {Type: "enum", Values: []string{"enterprise", "personal", "custom"}, CliFlag: nil},
 			}},
 			Flags: []FlagSchema{{Name: "request", Type: "string"}, {Name: "generate-skeleton", Type: "bool"}},
 		},
@@ -1310,7 +1317,7 @@ func buildHandwrittenSchemas() []CommandSchema {
 			RequestSchema: &RequestSchema{Type: "object", AdditionalProperties: false, Properties: map[string]PropertySchema{
 				"Image":             {Type: "string", CliFlag: nil},
 				"ImageDigest":       {Type: "string", CliFlag: nil},
-				"ImageRegistryType": {Type: "enum", Values: []string{"enterprise", "personal"}, CliFlag: nil},
+				"ImageRegistryType": {Type: "enum", Values: []string{"enterprise", "personal", "custom"}, CliFlag: nil},
 			}},
 			Args:  []ArgSchema{{Name: "ImageDigest", Type: "string", Required: true}},
 			Flags: []FlagSchema{{Name: "request", Type: "string"}, {Name: "generate-skeleton", Type: "bool"}},

--- a/internal/cli/schema_test.go
+++ b/internal/cli/schema_test.go
@@ -10,6 +10,7 @@ func TestSchemaFromDescriptorInfersEffects(t *testing.T) {
 	tests := []struct {
 		name            string
 		effects         []string
+		source          string
 		mutation        bool
 		createsResource bool
 		requiresAuth    bool
@@ -28,13 +29,32 @@ func TestSchemaFromDescriptorInfersEffects(t *testing.T) {
 			requiresAuth: true,
 		},
 		{
+			name:         "update effect",
+			effects:      []string{"update:identity"},
+			mutation:     true,
+			requiresAuth: true,
+		},
+		{
 			name: "no effect",
+		},
+		{
+			// Workflow commands always hit the cloud control plane, so they
+			// require auth even with no declared side-effects.
+			name:         "workflow source without effects",
+			source:       command.SourceWorkflow,
+			requiresAuth: true,
+		},
+		{
+			// A non-workflow source with no effects must stay auth-free.
+			name:   "apicli source without effects",
+			source: command.SourceAPICli,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			schema := schemaFromDescriptor(command.Descriptor{
+				Source: tt.source,
 				Spec: command.Spec{
 					ID:           "test.command",
 					Output:       command.OutputSpec{Effects: tt.effects},

--- a/internal/cmdtree/build.go
+++ b/internal/cmdtree/build.go
@@ -406,7 +406,7 @@ func validateSpec(spec command.Spec) error {
 
 func validateGeneratedAPIMetadata(desc command.Descriptor) error {
 	if desc.Generated == nil {
-		if desc.Source == "mixed-api" && desc.API != nil {
+		if desc.Source == command.SourceMixedAPI && desc.API != nil {
 			return fmt.Errorf("mixed API command %q missing generated descriptor snapshot", desc.Spec.ID)
 		}
 		return nil
@@ -433,7 +433,7 @@ func validateMixedOutput(desc command.Descriptor) error {
 	if desc.API == nil {
 		return nil
 	}
-	if desc.Source == "apicli" {
+	if desc.Source == command.SourceAPICli {
 		return nil
 	}
 	if desc.Spec.Output.DataType == "" {

--- a/internal/cmdtree/build_test.go
+++ b/internal/cmdtree/build_test.go
@@ -197,7 +197,7 @@ func TestBuildRejectsMixedModuleMissingOutputDataType(t *testing.T) {
 
 func TestBuildRejectsNonDefaultAPIModuleMissingOutputDataType(t *testing.T) {
 	module := mixedAPIModule()
-	module.Descriptor.Source = "workflow"
+	module.Descriptor.Source = command.SourceWorkflow
 	module.Descriptor.Spec.Output.DataType = ""
 	err := buildSingle(module)
 	if err == nil || !strings.Contains(err.Error(), "must declare output data type") {
@@ -308,11 +308,11 @@ func mixedAPIModule() command.Module {
 				Spec:   generatedSpec,
 				Groups: api.Groups,
 				API:    api,
-				Source: "apicli",
+				Source: command.SourceAPICli,
 			},
 			Groups: api.Groups,
 			API:    api,
-			Source: "mixed-api",
+			Source: command.SourceMixedAPI,
 		},
 		Build: func(command.Deps) (command.Runtime, error) {
 			return command.Runtime{

--- a/internal/command/types.go
+++ b/internal/command/types.go
@@ -97,6 +97,13 @@ const (
 	FlagStringArray FlagType = "stringArray"
 )
 
+// Source constants identify the module family for diagnostics and schema output.
+const (
+	SourceAPICli   = "apicli"
+	SourceWorkflow = "workflow"
+	SourceMixedAPI = "mixed-api"
+)
+
 // FlagSpec describes one CLI flag attached to a command.
 type FlagSpec struct {
 	Name      string

--- a/internal/commands/api/call/command.go
+++ b/internal/commands/api/call/command.go
@@ -51,7 +51,7 @@ func Module() command.Module {
 					Long:  "Raw API access for debugging and unmapped control-plane operations.",
 				},
 			},
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/apikey/create/command.go
+++ b/internal/commands/apikey/create/command.go
@@ -28,11 +28,11 @@ func Module() command.Module {
 				Spec:   api.CommandSpec(),
 				Groups: api.Groups,
 				API:    api,
-				Source: "apicli",
+				Source: command.SourceAPICli,
 			},
 			Groups: api.Groups,
 			API:    api,
-			Source: "mixed-api",
+			Source: command.SourceMixedAPI,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/apikey/delete/command.go
+++ b/internal/commands/apikey/delete/command.go
@@ -26,11 +26,11 @@ func Module() command.Module {
 				Spec:   api.CommandSpec(),
 				Groups: api.Groups,
 				API:    api,
-				Source: "apicli",
+				Source: command.SourceAPICli,
 			},
 			Groups: api.Groups,
 			API:    api,
-			Source: "mixed-api",
+			Source: command.SourceMixedAPI,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			builder := apicli.NewRequestBuilder(api)

--- a/internal/commands/apikey/list/command.go
+++ b/internal/commands/apikey/list/command.go
@@ -27,11 +27,11 @@ func Module() command.Module {
 				Spec:   api.CommandSpec(),
 				Groups: api.Groups,
 				API:    api,
-				Source: "apicli",
+				Source: command.SourceAPICli,
 			},
 			Groups: api.Groups,
 			API:    api,
-			Source: "mixed-api",
+			Source: command.SourceMixedAPI,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			builder := apicli.NewRequestBuilder(api)

--- a/internal/commands/credential/oauth2/acquire/command.go
+++ b/internal/commands/credential/oauth2/acquire/command.go
@@ -45,7 +45,7 @@ Use "agr credential oauth2 acquire --session-uri <uri>" to poll the session.`,
 				{Path: []string{"credential"}, Use: "credential", Short: "Manage credentials and providers"},
 				{Path: []string{"credential", "oauth2"}, Use: "oauth2", Short: "OAuth2 authorization workflows"},
 			},
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/credential/oauth2/complete/command.go
+++ b/internal/commands/credential/oauth2/complete/command.go
@@ -36,7 +36,7 @@ has been received. This finalizes the session so AccessToken can be obtained.`,
 				{Path: []string{"credential"}, Use: "credential", Short: "Manage credentials and providers"},
 				{Path: []string{"credential", "oauth2"}, Use: "oauth2", Short: "OAuth2 authorization workflows"},
 			},
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/credential/provider/create/command.go
+++ b/internal/commands/credential/provider/create/command.go
@@ -50,7 +50,7 @@ Config is a JSON array of {Key, Value} pairs. Required config keys depend on typ
 		Descriptor: command.Descriptor{
 			Spec:   spec,
 			Groups: credentialProviderGroups(),
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/credential/provider/delete/command.go
+++ b/internal/commands/credential/provider/delete/command.go
@@ -33,7 +33,7 @@ SecretMultiUser providers also require all secrets to be removed first.`,
 		Descriptor: command.Descriptor{
 			Spec:   spec,
 			Groups: []command.GroupSpec{{Path: []string{"credential"}, Use: "credential", Short: "Manage credentials and providers"}, {Path: []string{"credential", "provider"}, Use: "provider", Short: "Manage credential providers"}},
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/credential/provider/get/command.go
+++ b/internal/commands/credential/provider/get/command.go
@@ -28,7 +28,7 @@ func Module() command.Module {
 		Descriptor: command.Descriptor{
 			Spec:   spec,
 			Groups: []command.GroupSpec{{Path: []string{"credential"}, Use: "credential", Short: "Manage credentials and providers"}, {Path: []string{"credential", "provider"}, Use: "provider", Short: "Manage credential providers"}},
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/credential/provider/list/command.go
+++ b/internal/commands/credential/provider/list/command.go
@@ -42,7 +42,7 @@ Supports filtering by provider IDs, type (via --filter type=AKSK), and tags.`,
 				{Path: []string{"credential"}, Use: "credential", Short: "Manage credentials and providers"},
 				{Path: []string{"credential", "provider"}, Use: "provider", Short: "Manage credential providers"},
 			},
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/credential/provider/update/command.go
+++ b/internal/commands/credential/provider/update/command.go
@@ -46,7 +46,7 @@ A provider must be DISABLED before deletion.`,
 				{Path: []string{"credential"}, Use: "credential", Short: "Manage credentials and providers"},
 				{Path: []string{"credential", "provider"}, Use: "provider", Short: "Manage credential providers"},
 			},
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/credential/secret/delete/command.go
+++ b/internal/commands/credential/secret/delete/command.go
@@ -40,7 +40,7 @@ If omitted, all secrets for the user are deleted.`,
 				{Path: []string{"credential"}, Use: "credential", Short: "Manage credentials and providers"},
 				{Path: []string{"credential", "secret"}, Use: "secret", Short: "Manage per-user managed secrets"},
 			},
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/credential/secret/get/command.go
+++ b/internal/commands/credential/secret/get/command.go
@@ -40,7 +40,7 @@ and user context. The token determines which user's secret is returned.`,
 				{Path: []string{"credential"}, Use: "credential", Short: "Manage credentials and providers"},
 				{Path: []string{"credential", "secret"}, Use: "secret", Short: "Manage per-user managed secrets"},
 			},
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/credential/secret/list/command.go
+++ b/internal/commands/credential/secret/list/command.go
@@ -37,7 +37,7 @@ func Module() command.Module {
 				{Path: []string{"credential"}, Use: "credential", Short: "Manage credentials and providers"},
 				{Path: []string{"credential", "secret"}, Use: "secret", Short: "Manage per-user managed secrets"},
 			},
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/credential/secret/set/command.go
+++ b/internal/commands/credential/secret/set/command.go
@@ -45,7 +45,7 @@ The secret value is accepted via --secret or --from-stdin (piped input).`,
 				{Path: []string{"credential"}, Use: "credential", Short: "Manage credentials and providers"},
 				{Path: []string{"credential", "secret"}, Use: "secret", Short: "Manage per-user managed secrets"},
 			},
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/identity/controlplane.go
+++ b/internal/commands/identity/controlplane.go
@@ -7,7 +7,7 @@
 // stabilizes and is added to api.json + mapping.yaml:
 //
 //  1. Run `go run ./cmd/internal/cobragen` to generate api.generated.go
-//  2. Change Source from "workflow" to "mixed-api"
+//  2. Change Source from command.SourceWorkflow to command.SourceMixedAPI
 //  3. Reference APIDescriptor() for flags (keeps custom validation/rendering)
 //
 // The command IDs, paths, and flag names are chosen to match the expected

--- a/internal/commands/identity/create/command.go
+++ b/internal/commands/identity/create/command.go
@@ -42,7 +42,7 @@ to obtain WorkloadAccessTokens and associate with CredentialProviders.`,
 		Descriptor: command.Descriptor{
 			Spec:   spec,
 			Groups: identityGroups(),
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/identity/delete/command.go
+++ b/internal/commands/identity/delete/command.go
@@ -26,7 +26,7 @@ func Module() command.Module {
 		Descriptor: command.Descriptor{
 			Spec:   spec,
 			Groups: []command.GroupSpec{{Path: []string{"identity"}, Use: "identity", Short: "Manage workload identities"}},
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/identity/get/command.go
+++ b/internal/commands/identity/get/command.go
@@ -25,7 +25,7 @@ func Module() command.Module {
 		Descriptor: command.Descriptor{
 			Spec:   spec,
 			Groups: []command.GroupSpec{{Path: []string{"identity"}, Use: "identity", Short: "Manage workload identities"}},
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/identity/list/command.go
+++ b/internal/commands/identity/list/command.go
@@ -35,7 +35,7 @@ func Module() command.Module {
 		Descriptor: command.Descriptor{
 			Spec:   spec,
 			Groups: []command.GroupSpec{{Path: []string{"identity"}, Use: "identity", Short: "Manage workload identities"}},
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/identity/token/create/command.go
+++ b/internal/commands/identity/token/create/command.go
@@ -42,7 +42,7 @@ get the full token value.`,
 				{Path: []string{"identity"}, Use: "identity", Short: "Manage workload identities"},
 				{Path: []string{"identity", "token"}, Use: "token", Short: "Manage workload access tokens"},
 			},
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/identity/update/command.go
+++ b/internal/commands/identity/update/command.go
@@ -34,7 +34,7 @@ func Module() command.Module {
 		Descriptor: command.Descriptor{
 			Spec:   spec,
 			Groups: []command.GroupSpec{{Path: []string{"identity"}, Use: "identity", Short: "Manage workload identities"}},
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/instance/browser/vnc/command.go
+++ b/internal/commands/instance/browser/vnc/command.go
@@ -51,7 +51,7 @@ Examples:
 				},
 				{Path: []string{"instance", "browser"}, Use: "browser", Short: "Browser sandbox commands"},
 			},
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/instance/code/run/command.go
+++ b/internal/commands/instance/code/run/command.go
@@ -70,7 +70,7 @@ Supported languages: python (default), javascript, typescript, r, java, bash`,
 				},
 				{Path: []string{"instance", "code"}, Use: "code", Short: "Code execution commands"},
 			},
-			Source: "workflow",
+			Source: cmdcore.SourceWorkflow,
 		},
 		Build: func(deps cmdcore.Deps) (cmdcore.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/instance/create/command.go
+++ b/internal/commands/instance/create/command.go
@@ -34,11 +34,11 @@ func Module() command.Module {
 				Spec:   api.CommandSpec(),
 				Groups: api.Groups,
 				API:    api,
-				Source: "apicli",
+				Source: command.SourceAPICli,
 			},
 			Groups: api.Groups,
 			API:    api,
-			Source: "mixed-api",
+			Source: command.SourceMixedAPI,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/instance/debug/command.go
+++ b/internal/commands/instance/debug/command.go
@@ -98,7 +98,7 @@ func Module() command.Module {
 					Aliases: []string{"i"},
 				},
 			},
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			cp, ok := deps.ControlPlane.(ControlPlane)

--- a/internal/commands/instance/delete/command.go
+++ b/internal/commands/instance/delete/command.go
@@ -90,11 +90,11 @@ func Module() command.Module {
 				Spec:   generatedSpec,
 				Groups: api.Groups,
 				API:    api,
-				Source: "apicli",
+				Source: command.SourceAPICli,
 			},
 			Groups: api.Groups,
 			API:    api,
-			Source: "mixed-api",
+			Source: command.SourceMixedAPI,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/instance/exec/command.go
+++ b/internal/commands/instance/exec/command.go
@@ -67,7 +67,7 @@ Examples:
 					Aliases: []string{"i"},
 				},
 			},
-			Source: "workflow",
+			Source: cmdcore.SourceWorkflow,
 		},
 		Build: func(deps cmdcore.Deps) (cmdcore.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/instance/file/download/command.go
+++ b/internal/commands/instance/file/download/command.go
@@ -56,7 +56,7 @@ Examples:
   agr instance file download ins-xxxx /home/user/data.txt -`,
 				},
 			},
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/instance/file/upload/command.go
+++ b/internal/commands/instance/file/upload/command.go
@@ -60,7 +60,7 @@ Examples:
   agr instance file download ins-xxxx /home/user/data.txt -`,
 				},
 			},
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/instance/get/command.go
+++ b/internal/commands/instance/get/command.go
@@ -41,7 +41,7 @@ func Module() command.Module {
 				Long:    "Manage sandbox instances and related data-plane workflows.",
 				Aliases: []string{"i"},
 			}},
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			cp, ok := deps.ControlPlane.(ControlPlane)

--- a/internal/commands/instance/list/command.go
+++ b/internal/commands/instance/list/command.go
@@ -39,11 +39,11 @@ func Module() command.Module {
 				Spec:   api.CommandSpec(),
 				Groups: api.Groups,
 				API:    api,
-				Source: "apicli",
+				Source: command.SourceAPICli,
 			},
 			Groups: api.Groups,
 			API:    api,
-			Source: "mixed-api",
+			Source: command.SourceMixedAPI,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			builder := apicli.NewRequestBuilder(api)

--- a/internal/commands/instance/login/command.go
+++ b/internal/commands/instance/login/command.go
@@ -67,7 +67,7 @@ Examples:
 				Long:    "Manage sandbox instances and related data-plane workflows.",
 				Aliases: []string{"i"},
 			}},
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/instance/mobile/adb/command.go
+++ b/internal/commands/instance/mobile/adb/command.go
@@ -61,7 +61,7 @@ Examples:
   agr instance mobile adb <instance-id> -- shell ls /sdcard
   agr instance mobile disconnect <instance-id>`},
 			},
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/instance/mobile/connect/command.go
+++ b/internal/commands/instance/mobile/connect/command.go
@@ -93,7 +93,7 @@ Examples:
   agr instance mobile disconnect <instance-id>`,
 				},
 			},
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/instance/mobile/disconnect/command.go
+++ b/internal/commands/instance/mobile/disconnect/command.go
@@ -61,7 +61,7 @@ Examples:
   agr instance mobile adb <instance-id> -- shell ls /sdcard
   agr instance mobile disconnect <instance-id>`},
 			},
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/instance/mobile/list/command.go
+++ b/internal/commands/instance/mobile/list/command.go
@@ -52,7 +52,7 @@ Examples:
   agr instance mobile adb <instance-id> -- shell ls /sdcard
   agr instance mobile disconnect <instance-id>`},
 			},
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/instance/mobile/tunnel/command.go
+++ b/internal/commands/instance/mobile/tunnel/command.go
@@ -70,7 +70,7 @@ Examples:
   agr instance mobile adb <instance-id> -- shell ls /sdcard
   agr instance mobile disconnect <instance-id>`},
 			},
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/instance/pause/command.go
+++ b/internal/commands/instance/pause/command.go
@@ -24,11 +24,11 @@ func Module() command.Module {
 				Spec:   generatedSpec,
 				Groups: api.Groups,
 				API:    api,
-				Source: "apicli",
+				Source: command.SourceAPICli,
 			},
 			Groups: api.Groups,
 			API:    api,
-			Source: "mixed-api",
+			Source: command.SourceMixedAPI,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			builder := apicli.NewRequestBuilder(api)

--- a/internal/commands/instance/proxy/command.go
+++ b/internal/commands/instance/proxy/command.go
@@ -68,7 +68,7 @@ Examples:
 					Aliases: []string{"i"},
 				},
 			},
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/instance/resume/command.go
+++ b/internal/commands/instance/resume/command.go
@@ -24,11 +24,11 @@ func Module() command.Module {
 				Spec:   generatedSpec,
 				Groups: api.Groups,
 				API:    api,
-				Source: "apicli",
+				Source: command.SourceAPICli,
 			},
 			Groups: api.Groups,
 			API:    api,
-			Source: "mixed-api",
+			Source: command.SourceMixedAPI,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			builder := apicli.NewRequestBuilder(api)

--- a/internal/commands/instance/update/command.go
+++ b/internal/commands/instance/update/command.go
@@ -24,11 +24,11 @@ func Module() command.Module {
 				Spec:   generatedSpec,
 				Groups: api.Groups,
 				API:    api,
-				Source: "apicli",
+				Source: command.SourceAPICli,
 			},
 			Groups: api.Groups,
 			API:    api,
-			Source: "mixed-api",
+			Source: command.SourceMixedAPI,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			builder := apicli.NewRequestBuilder(api)

--- a/internal/commands/precacheimagetask/create/command.go
+++ b/internal/commands/precacheimagetask/create/command.go
@@ -20,11 +20,11 @@ func Module() command.Module {
 				Spec:   spec,
 				Groups: api.Groups,
 				API:    api,
-				Source: "apicli",
+				Source: command.SourceAPICli,
 			},
 			Groups: api.Groups,
 			API:    api,
-			Source: "mixed-api",
+			Source: command.SourceMixedAPI,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			builder := apicli.NewRequestBuilder(api)

--- a/internal/commands/precacheimagetask/get/command.go
+++ b/internal/commands/precacheimagetask/get/command.go
@@ -20,11 +20,11 @@ func Module() command.Module {
 				Spec:   spec,
 				Groups: api.Groups,
 				API:    api,
-				Source: "apicli",
+				Source: command.SourceAPICli,
 			},
 			Groups: api.Groups,
 			API:    api,
-			Source: "mixed-api",
+			Source: command.SourceMixedAPI,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			builder := apicli.NewRequestBuilder(api)

--- a/internal/commands/tool/create/command.go
+++ b/internal/commands/tool/create/command.go
@@ -29,11 +29,11 @@ func Module() command.Module {
 				Spec:   generatedSpec,
 				Groups: api.Groups,
 				API:    api,
-				Source: "apicli",
+				Source: command.SourceAPICli,
 			},
 			Groups: api.Groups,
 			API:    api,
-			Source: "mixed-api",
+			Source: command.SourceMixedAPI,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/tool/delete/command.go
+++ b/internal/commands/tool/delete/command.go
@@ -79,11 +79,11 @@ func Module() command.Module {
 				Spec:   generatedSpec,
 				Groups: api.Groups,
 				API:    api,
-				Source: "apicli",
+				Source: command.SourceAPICli,
 			},
 			Groups: api.Groups,
 			API:    api,
-			Source: "mixed-api",
+			Source: command.SourceMixedAPI,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			deps = deps.WithDefaults()

--- a/internal/commands/tool/fork/command.go
+++ b/internal/commands/tool/fork/command.go
@@ -39,7 +39,7 @@ func Module() command.Module {
 			Spec:   spec,
 			Groups: groups,
 			API:    api,
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			cp, ok := deps.ControlPlane.(ControlPlane)

--- a/internal/commands/tool/get/command.go
+++ b/internal/commands/tool/get/command.go
@@ -49,7 +49,7 @@ func Module() command.Module {
 		Descriptor: command.Descriptor{
 			Spec:   spec,
 			Groups: groups,
-			Source: "workflow",
+			Source: command.SourceWorkflow,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			cp, ok := deps.ControlPlane.(ControlPlane)

--- a/internal/commands/tool/list/command.go
+++ b/internal/commands/tool/list/command.go
@@ -30,11 +30,11 @@ func Module() command.Module {
 				Spec:   api.CommandSpec(),
 				Groups: api.Groups,
 				API:    api,
-				Source: "apicli",
+				Source: command.SourceAPICli,
 			},
 			Groups: api.Groups,
 			API:    api,
-			Source: "mixed-api",
+			Source: command.SourceMixedAPI,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			builder := apicli.NewRequestBuilder(api)

--- a/internal/commands/tool/update/command.go
+++ b/internal/commands/tool/update/command.go
@@ -26,11 +26,11 @@ func Module() command.Module {
 				Spec:   generatedSpec,
 				Groups: api.Groups,
 				API:    api,
-				Source: "apicli",
+				Source: command.SourceAPICli,
 			},
 			Groups: api.Groups,
 			API:    api,
-			Source: "mixed-api",
+			Source: command.SourceMixedAPI,
 		},
 		Build: func(deps command.Deps) (command.Runtime, error) {
 			builder := apicli.NewRequestBuilder(api)

--- a/tests/integ/integ_test.go
+++ b/tests/integ/integ_test.go
@@ -643,3 +643,158 @@ func TestCompletion_ZshOutput(t *testing.T) {
 		t.Fatalf("completion zsh output unexpected:\n%s", r.stdout[:min(len(r.stdout), 200)])
 	}
 }
+
+// --- Schema metadata correctness (issue #94) ---
+
+func TestSchema_UpdateCommandsAreMutations(t *testing.T) {
+	// Dynamically discover all *.update commands and assert Mutation: true.
+	r := run(t, "schema", "-o", "json")
+	if r.exitCode != 0 {
+		t.Fatalf("exit code = %d\nstderr: %s\nstdout: %s", r.exitCode, r.stderr, r.stdout)
+	}
+	env := parseEnvelope(t, r.stdout)
+	rawCmds, ok := env.Data["Commands"].([]any)
+	if !ok {
+		t.Fatalf("Data.Commands not an array: %T", env.Data["Commands"])
+	}
+	var updateCmds []string
+	for _, raw := range rawCmds {
+		m, _ := raw.(map[string]any)
+		name, _ := m["Name"].(string)
+		if strings.HasSuffix(name, ".update") {
+			updateCmds = append(updateCmds, name)
+		}
+	}
+	if len(updateCmds) == 0 {
+		t.Fatal("no *.update commands discovered from schema output")
+	}
+	for _, cmd := range updateCmds {
+		t.Run(cmd, func(t *testing.T) {
+			r := run(t, "schema", cmd, "-o", "json")
+			if r.exitCode != 0 {
+				t.Fatalf("exit code = %d\nstderr: %s\nstdout: %s", r.exitCode, r.stderr, r.stdout)
+			}
+			cmdEnv := parseEnvelope(t, r.stdout)
+			mutation, ok := cmdEnv.Data["Mutation"].(bool)
+			if !ok {
+				t.Fatalf("Data.Mutation not a bool: %v", cmdEnv.Data["Mutation"])
+			}
+			if !mutation {
+				t.Fatalf("schema %s: Mutation = false, want true", cmd)
+			}
+		})
+	}
+}
+
+func TestSchema_WorkflowCommandsRequireAuth(t *testing.T) {
+	// Workflow commands that call the cloud control plane must report
+	// RequiresAuth: true. We verify this from the full schema listing in one
+	// pass — no per-command sub-requests needed.
+	//
+	// The expected set below is maintained explicitly so that any new workflow
+	// command that forgets to declare auth will cause a test failure.
+	expectedAuthCmds := map[string]bool{
+		"identity.create":            true,
+		"identity.get":               true,
+		"identity.list":              true,
+		"identity.update":            true,
+		"identity.delete":            true,
+		"identity.token.create":      true,
+		"credential.provider.create": true,
+		"credential.provider.get":    true,
+		"credential.provider.list":   true,
+		"credential.provider.update": true,
+		"credential.provider.delete": true,
+		"credential.secret.set":      true,
+		"credential.secret.get":      true,
+		"credential.secret.list":     true,
+		"credential.secret.delete":   true,
+		"credential.oauth2.acquire":  true,
+		"credential.oauth2.complete": true,
+	}
+
+	r := run(t, "schema", "-o", "json")
+	if r.exitCode != 0 {
+		t.Fatalf("exit code = %d\nstderr: %s\nstdout: %s", r.exitCode, r.stderr, r.stdout)
+	}
+	env := parseEnvelope(t, r.stdout)
+	rawCmds, ok := env.Data["Commands"].([]any)
+	if !ok {
+		t.Fatalf("Data.Commands not an array: %T", env.Data["Commands"])
+	}
+
+	seen := make(map[string]bool)
+	for _, raw := range rawCmds {
+		m, _ := raw.(map[string]any)
+		name, _ := m["Name"].(string)
+		kind, _ := m["Kind"].(string)
+		if kind != "command" {
+			continue
+		}
+		requiresAuth, _ := m["RequiresAuth"].(bool)
+
+		if expectedAuthCmds[name] {
+			seen[name] = true
+			if !requiresAuth {
+				t.Errorf("schema %s: RequiresAuth = false, want true", name)
+			}
+		}
+	}
+
+	// Ensure all expected commands were found in the schema output.
+	for cmd := range expectedAuthCmds {
+		if !seen[cmd] {
+			t.Errorf("expected workflow command %q not found in schema output", cmd)
+		}
+	}
+}
+
+func TestSchema_PreCacheImageRegistryTypeIncludesCustom(t *testing.T) {
+	// The ImageRegistryType enum in pre-cache-image-task commands should
+	// include "custom" in addition to "enterprise" and "personal".
+	cmds := []string{
+		"pre-cache-image-task.create",
+		"pre-cache-image-task.get",
+	}
+	for _, cmd := range cmds {
+		t.Run(cmd, func(t *testing.T) {
+			r := run(t, "schema", cmd, "-o", "json")
+			if r.exitCode != 0 {
+				t.Fatalf("exit code = %d\nstderr: %s\nstdout: %s", r.exitCode, r.stderr, r.stdout)
+			}
+			env := parseEnvelope(t, r.stdout)
+			reqSchema, ok := env.Data["RequestSchema"].(map[string]any)
+			if !ok {
+				t.Fatalf("Data.RequestSchema not an object: %v", env.Data["RequestSchema"])
+			}
+			props, ok := reqSchema["Properties"].(map[string]any)
+			if !ok {
+				t.Fatalf("RequestSchema.Properties not an object: %v", reqSchema["Properties"])
+			}
+			irt, ok := props["ImageRegistryType"].(map[string]any)
+			if !ok {
+				t.Fatalf("Properties.ImageRegistryType not an object: %v", props["ImageRegistryType"])
+			}
+			rawValues, ok := irt["Values"].([]any)
+			if !ok {
+				t.Fatalf("ImageRegistryType.Values not an array: %v", irt["Values"])
+			}
+			values := make([]string, len(rawValues))
+			for i, v := range rawValues {
+				values[i], _ = v.(string)
+			}
+			for _, want := range []string{"enterprise", "personal", "custom"} {
+				found := false
+				for _, v := range values {
+					if v == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("schema %s: ImageRegistryType.Values = %v, missing %q", cmd, values, want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fix schema metadata inconsistencies reported in #94:

1. **Mutation flag**: `schemaEffects()` now recognizes `"update"` as a mutation (previously only `create`/`delete` were handled)
2. **RequiresAuth flag**: All workflow-source commands (`identity.*`, `credential.*`) now correctly report `RequiresAuth: true`, even read-only ones
3. **ImageRegistryType enum**: `pre-cache-image-task.create/get` schema now includes `"custom"` alongside `"enterprise"` and `"personal"`

## Additional improvements

- Introduced typed constants `command.SourceWorkflow`, `command.SourceAPICli`, `command.SourceMixedAPI` replacing bare string literals across56 files to prevent typos
- Added E2E tests:
  - `TestSchema_UpdateCommandsAreMutations` — dynamically discovers all `*.update` commands and asserts `Mutation: true`
  - `TestSchema_WorkflowCommandsRequireAuth` — validates explicit expected set of workflow commands from full schema JSON
  - `TestSchema_PreCacheImageRegistryTypeIncludesCustom` — precise JSON parsing of enum values

## Testing

- `go test -count=1 ./...` all pass
- `gofmt` / `go vet` clean
- `cobragen check` consistent

Closes #94