### PR TITLE
fix(debug): align instance wait lifecycle

### DIFF
--- a/internal/commands/instance/debug/command.go
+++ b/internal/commands/instance/debug/command.go
@@ -239,6 +239,10 @@ func runDebug(ctx context.Context, req command.Request, deps command.Deps, cp Co
 	instance, err := waitForInstanceRunning(ctx, cp, instanceID, resourcewait.OptionsFromDeps(deps))
 	if err != nil {
 		cleanupDebugResources(deps, cp, instanceID, debugToolID)
+		cliErr := output.ClassifyError(err)
+		if cliErr != nil && cliErr.Failure != nil && strings.HasPrefix(cliErr.Failure.Code, "WAIT_") {
+			cliErr.Failure.Hint = "Cleanup was attempted for the temporary debug resources. Re-run the same 'agr instance debug' command to retry."
+		}
 		return nil, err
 	}
 

--- a/internal/commands/instance/debug/command.go
+++ b/internal/commands/instance/debug/command.go
@@ -11,6 +11,7 @@ import (
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/cli/request"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
 	instanceview "github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/instance/internal/instanceview"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/internal/resourcewait"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/internal/tooltags"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/output"
 	ags "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ags/v20250920"
@@ -235,7 +236,7 @@ func runDebug(ctx context.Context, req command.Request, deps command.Deps, cp Co
 		cleanupDebugResources(deps, cp, "", debugToolID)
 		return nil, fmt.Errorf("no instance id returned from StartSandboxInstance")
 	}
-	instance, err := waitForInstanceRunning(ctx, cp, instanceID)
+	instance, err := waitForInstanceRunning(ctx, cp, instanceID, resourcewait.OptionsFromDeps(deps))
 	if err != nil {
 		cleanupDebugResources(deps, cp, instanceID, debugToolID)
 		return nil, err
@@ -300,25 +301,14 @@ func waitForToolReady(ctx context.Context, cp ControlPlane, toolID string) (*ags
 	}
 }
 
-func waitForInstanceRunning(ctx context.Context, cp ControlPlane, instanceID string) (*ags.SandboxInstance, error) {
-	waitCtx, cancel := context.WithTimeout(ctx, debugReadyTimeout)
-	defer cancel()
-	for {
-		instance, err := cp.GetInstance(waitCtx, instanceID)
-		if err != nil {
-			return nil, err
-		}
-		status := strings.ToUpper(derefString(instance.Status))
-		switch status {
-		case "RUNNING":
-			return instance, nil
-		case "FAILED", "STOPPED", "STOP_FAILED":
-			return nil, fmt.Errorf("debug instance %s failed to become ready (status: %s)", instanceID, status)
-		}
-		if err := waitBeforeRetry(waitCtx); err != nil {
-			return nil, fmt.Errorf("timed out waiting for debug instance %s to become ready: %w", instanceID, err)
-		}
-	}
+func waitForInstanceRunning(ctx context.Context, cp ControlPlane, instanceID string, options resourcewait.Options) (*ags.SandboxInstance, error) {
+	return resourcewait.WaitForInstanceWithPolicy(
+		ctx,
+		instanceID,
+		cp.GetInstance,
+		resourcewait.InstancePolicy(resourcewait.OperationCreate),
+		options,
+	)
 }
 
 func waitBeforeRetry(ctx context.Context) error {

--- a/internal/commands/instance/debug/command_test.go
+++ b/internal/commands/instance/debug/command_test.go
@@ -250,6 +250,7 @@ func TestModuleCleansUpInstanceThenToolOnInstanceFailure(t *testing.T) {
 	}
 	_, err = runtime.Handler.Run(context.Background(), command.Request{Flags: map[string]command.FlagValue{"tool-id": {Name: "tool-id", Type: command.FlagString, String: "sdt-source", Changed: true}}})
 	assertDebugWaitError(t, err, "WAIT_FAILED", failed)
+	assertDebugCleanupHint(t, err)
 	if got, want := strings.Join(cp.deletes, ","), "instance:ins-debug,tool:sdt-debug"; got != want {
 		t.Fatalf("deletes = %q, want %q", got, want)
 	}
@@ -285,6 +286,7 @@ func TestModuleInstanceWaitTimeoutIncludesLastStatus(t *testing.T) {
 	defer cancel()
 	_, err = runtime.Handler.Run(ctx, command.Request{Flags: map[string]command.FlagValue{"tool-id": {Name: "tool-id", Type: command.FlagString, String: "sdt-source", Changed: true}}})
 	assertDebugWaitError(t, err, "WAIT_TIMEOUT", starting)
+	assertDebugCleanupHint(t, err)
 	if got, want := strings.Join(cp.deletes, ","), "instance:ins-debug,tool:sdt-debug"; got != want {
 		t.Fatalf("deletes = %q, want %q", got, want)
 	}
@@ -517,6 +519,18 @@ func assertDebugWaitError(t *testing.T, err error, code, lastStatus string) {
 	if details["ResourceType"] != "instance" || details["ResourceId"] != "ins-debug" ||
 		details["Operation"] != string(resourcewait.OperationCreate) || details["LastStatus"] != lastStatus {
 		t.Fatalf("failure details = %#v", details)
+	}
+}
+
+func assertDebugCleanupHint(t *testing.T, err error) {
+	t.Helper()
+	cliErr := output.ClassifyError(err)
+	if cliErr == nil || cliErr.Failure == nil {
+		t.Fatalf("error = %T %v, want classified failure", err, err)
+	}
+	want := "Cleanup was attempted for the temporary debug resources. Re-run the same 'agr instance debug' command to retry."
+	if cliErr.Failure.Hint != want {
+		t.Fatalf("failure hint = %q, want %q", cliErr.Failure.Hint, want)
 	}
 }
 

--- a/internal/commands/instance/debug/command_test.go
+++ b/internal/commands/instance/debug/command_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/command"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/commands/internal/resourcewait"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/iostreams"
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/output"
 	ags "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/ags/v20250920"
@@ -232,19 +233,58 @@ func TestModuleCleansUpOnToolReadyFailure(t *testing.T) {
 }
 
 func TestModuleCleansUpInstanceThenToolOnInstanceFailure(t *testing.T) {
-	failed := "FAILED"
+	failed := "STARTING_FAILED"
 	cp := &fakeControlPlane{
 		sourceTool: sourceTool(),
 		instance:   &ags.SandboxInstance{InstanceId: strPtr("ins-debug"), Status: &failed},
 	}
-	runtime, err := Module().Build(command.Deps{ControlPlane: cp})
+	runtime, err := Module().Build(command.Deps{
+		ControlPlane: cp,
+		Values: map[string]any{resourcewait.OptionsKey: resourcewait.Options{
+			Interval: time.Millisecond,
+			Timeout:  50 * time.Millisecond,
+		}},
+	})
 	if err != nil {
 		t.Fatalf("Build returned error: %v", err)
 	}
 	_, err = runtime.Handler.Run(context.Background(), command.Request{Flags: map[string]command.FlagValue{"tool-id": {Name: "tool-id", Type: command.FlagString, String: "sdt-source", Changed: true}}})
-	if err == nil || !strings.Contains(err.Error(), "debug instance ins-debug failed") {
-		t.Fatalf("error = %v, want instance ready failure", err)
+	assertDebugWaitError(t, err, "WAIT_FAILED", failed)
+	if got, want := strings.Join(cp.deletes, ","), "instance:ins-debug,tool:sdt-debug"; got != want {
+		t.Fatalf("deletes = %q, want %q", got, want)
 	}
+}
+
+func TestWaitForInstanceRunningReturnsStructuredErrorWhenPreempted(t *testing.T) {
+	stopped := "STOPPED"
+	cp := &fakeControlPlane{instance: &ags.SandboxInstance{InstanceId: strPtr("ins-debug"), Status: &stopped}}
+	_, err := waitForInstanceRunning(context.Background(), cp, "ins-debug", resourcewait.Options{
+		Interval: time.Millisecond,
+		Timeout:  50 * time.Millisecond,
+	})
+	assertDebugWaitError(t, err, "WAIT_PREEMPTED", stopped)
+}
+
+func TestModuleInstanceWaitTimeoutIncludesLastStatus(t *testing.T) {
+	starting := "STARTING"
+	cp := &fakeControlPlane{
+		sourceTool: sourceTool(),
+		instance:   &ags.SandboxInstance{InstanceId: strPtr("ins-debug"), Status: &starting},
+	}
+	runtime, err := Module().Build(command.Deps{
+		ControlPlane: cp,
+		Values: map[string]any{resourcewait.OptionsKey: resourcewait.Options{
+			Interval: time.Millisecond,
+			Timeout:  5 * time.Millisecond,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err = runtime.Handler.Run(ctx, command.Request{Flags: map[string]command.FlagValue{"tool-id": {Name: "tool-id", Type: command.FlagString, String: "sdt-source", Changed: true}}})
+	assertDebugWaitError(t, err, "WAIT_TIMEOUT", starting)
 	if got, want := strings.Join(cp.deletes, ","), "instance:ins-debug,tool:sdt-debug"; got != want {
 		t.Fatalf("deletes = %q, want %q", got, want)
 	}
@@ -264,9 +304,7 @@ func TestModuleReturnsCleanupWarnings(t *testing.T) {
 		t.Fatalf("Build returned error: %v", err)
 	}
 	_, err = runtime.Handler.Run(context.Background(), command.Request{Flags: map[string]command.FlagValue{"tool-id": {Name: "tool-id", Type: command.FlagString, String: "sdt-source", Changed: true}}})
-	if err == nil || !strings.Contains(err.Error(), "debug instance ins-debug failed") {
-		t.Fatalf("error = %v, want primary instance failure", err)
-	}
+	assertDebugWaitError(t, err, "WAIT_FAILED", failed)
 	warnings := stderr.String()
 	if !strings.Contains(warnings, "Warning: failed to cleanup debug instance ins-debug: delete instance boom") ||
 		!strings.Contains(warnings, "Warning: failed to cleanup debug tool sdt-debug: delete tool boom") {
@@ -465,5 +503,21 @@ func strPtr(value string) *string { return &value }
 func boolPtr(value bool) *bool { return &value }
 
 func int64Ptr(value int64) *int64 { return &value }
+
+func assertDebugWaitError(t *testing.T, err error, code, lastStatus string) {
+	t.Helper()
+	var cliErr *output.CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("error = %T %v, want *output.CLIError", err, err)
+	}
+	if cliErr.Failure.Code != code {
+		t.Fatalf("failure code = %q, want %q: %#v", cliErr.Failure.Code, code, cliErr.Failure)
+	}
+	details := cliErr.Failure.Details
+	if details["ResourceType"] != "instance" || details["ResourceId"] != "ins-debug" ||
+		details["Operation"] != string(resourcewait.OperationCreate) || details["LastStatus"] != lastStatus {
+		t.Fatalf("failure details = %#v", details)
+	}
+}
 
 var _ ControlPlane = (*fakeControlPlane)(nil)


### PR DESCRIPTION
## Summary

- reuse the shared instance-create lifecycle policy for `agr instance debug`
- return structured `WAIT_FAILED`, `WAIT_PREEMPTED`, and `WAIT_TIMEOUT` errors
- preserve the last observed status and temporary-resource cleanup behavior
- replace generic waiter hints after cleanup with a viable debug-command retry hint

## Root cause

The debug workflow maintained a separate status switch from the shared instance waiter. As a result, statuses such as `STARTING_FAILED` were treated as transitional and could continue polling until the 10-minute timeout.

After adopting the shared waiter, its generic hint suggested inspecting or continuing to wait for an instance even though the debug workflow had already attempted to clean up that temporary instance and tool.

## Validation

- `go test ./internal/commands/instance/debug ./internal/commands/internal/resourcewait -count=1`
- `go test ./cmd/... ./internal/... -count=1`
- `golangci-lint run` (`0 issues`)
- `git diff --check d86f93d3d5e5bba4803f661278da83bffeead94a`

Fixes #97
