### PR TITLE
chore(ci): validate pull request titles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,38 @@ name: CI
 on:
   push:
   pull_request:
+    types: [opened, edited, synchronize, reopened]
 
 permissions:
   contents: read
 
 jobs:
+  pr-title:
+    name: Pull Request Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate pull request title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        shell: bash
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" != "pull_request" ]]; then
+            exit 0
+          fi
+
+          pattern='^(feat|fix|docs|style|refactor|test|chore)(\([^()]*[^()[:space:]][^()]*\))?!?: [^[:space:]].*$'
+          if [[ "$PR_TITLE" =~ $pattern ]]; then
+            exit 0
+          fi
+
+          echo "::error title=Invalid pull request title::Expected '<type>(<scope>)!: <description>' (scope and ! are optional). Allowed types: feat, fix, docs, style, refactor, test, chore."
+          echo "Examples:"
+          echo "  feat(tool): support computer configuration"
+          echo "  fix: handle an empty response"
+          echo "  feat(api)!: remove the legacy request format"
+          echo "Actual title: $PR_TITLE"
+          exit 1
+
   workflow-lint:
     name: Workflow Lint
     runs-on: ubuntu-latest
@@ -200,6 +227,7 @@ jobs:
     name: CI Gate
     if: ${{ always() }}
     needs:
+      - pr-title
       - workflow-lint
       - fmt
       - test

--- a/CONTRIBUTING-zh.md
+++ b/CONTRIBUTING-zh.md
@@ -14,7 +14,7 @@
   - [提交 Pull Request](#提交-pull-request)
 - [开发环境设置](#开发环境设置)
 - [编码规范](#编码规范)
-- [提交信息规范](#提交信息规范)
+- [提交信息与 Pull Request 标题规范](#提交信息与-pull-request-标题规范)
 - [审核流程](#审核流程)
 
 ## 行为准则
@@ -186,17 +186,19 @@ go run ./cmd/internal/apipatch rebase --upstream /tmp/ags-upstream-api.json
 - 保持注释与代码同步更新
 - 在适当的地方包含示例
 
-## 提交信息规范
+## 提交信息与 Pull Request 标题规范
 
-遵循 [Conventional Commits](https://www.conventionalcommits.org/) 规范：
+提交信息须遵循 [Conventional Commits](https://www.conventionalcommits.org/) 规范，Pull Request 标题须使用相同的首行格式。仓库使用 squash merge，因此 Pull Request 标题会成为默认分支上的提交标题。
 
 ```
-<type>(<scope>): <description>
+<type>(<scope>)!: <description>
 
 [可选的正文]
 
 [可选的脚注]
 ```
+
+scope 和破坏性变更标记（`!`）均为可选项。
 
 ### 类型
 
@@ -220,7 +222,7 @@ docs(readme): 更新安装说明
 
 ## 审核流程
 
-1. **自动检查**：必需状态检查为 `CI Gate` 和 `gitleaks`。`CI Gate` 聚合工作流校验、格式、测试、代码检查、变更日志和生成结果校验、Overlay 冒烟测试及发布就绪校验。
+1. **自动检查**：必需状态检查为 `CI Gate` 和 `gitleaks`。`CI Gate` 聚合 Pull Request 标题与工作流校验、格式、测试、代码检查、变更日志和生成结果校验、Overlay 冒烟测试及发布就绪校验。
 2. **代码审核**：需要至少一位维护者批准
 3. **测试覆盖**：需要足够的测试覆盖率
 4. **文档更新**：如需要则更新文档

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Thank you for your interest in contributing to AGR CLI! This document provides g
   - [Submitting Pull Requests](#submitting-pull-requests)
 - [Development Setup](#development-setup)
 - [Coding Guidelines](#coding-guidelines)
-- [Commit Messages](#commit-messages)
+- [Commit Messages and Pull Request Titles](#commit-messages-and-pull-request-titles)
 - [Review Process](#review-process)
 
 ## Code of Conduct
@@ -193,17 +193,19 @@ generated CLI diff.
 - Keep comments up to date with code changes
 - Include examples where helpful
 
-## Commit Messages
+## Commit Messages and Pull Request Titles
 
-Follow the [Conventional Commits](https://www.conventionalcommits.org/) specification:
+Follow the [Conventional Commits](https://www.conventionalcommits.org/) specification for commit messages. Pull request titles must use the same first-line format. Pull requests are squash merged, so the pull request title becomes the commit title on the default branch.
 
 ```
-<type>(<scope>): <description>
+<type>(<scope>)!: <description>
 
 [optional body]
 
 [optional footer(s)]
 ```
+
+The scope and breaking-change marker (`!`) are optional.
 
 ### Types
 
@@ -227,7 +229,7 @@ docs(readme): update installation instructions
 
 ## Review Process
 
-1. **Automated Checks**: The required status checks are `CI Gate` and `gitleaks`. `CI Gate` aggregates workflow validation, formatting, tests, linting, changelog and generated-output validation, overlay smoke tests, and release-readiness validation.
+1. **Automated Checks**: The required status checks are `CI Gate` and `gitleaks`. `CI Gate` aggregates pull request title and workflow validation, formatting, tests, linting, changelog and generated-output validation, overlay smoke tests, and release-readiness validation.
 2. **Code Review**: At least one maintainer approval required
 3. **Testing**: Adequate test coverage expected
 4. **Documentation**: Update docs if needed


### PR DESCRIPTION
## Summary

- validate pull request titles against the documented Conventional Commit types, including optional scopes and breaking-change markers
- rerun validation for opened, edited, synchronized, and reopened pull requests and aggregate it into `CI Gate`
- document squash-merge title requirements in both contributing guides

## Validation

- `actionlint -color`
- `git diff --check upstream/main...HEAD`
- valid and invalid pull request title fixtures
- push-event bypass fixture

Go tests were not run because this change only updates GitHub Actions and documentation. No CLI runtime behavior changes.

Closes #114