### PR TITLE
fix(api): support datetime_iso string members

### DIFF
--- a/internal/apimeta/effective.go
+++ b/internal/apimeta/effective.go
@@ -465,7 +465,7 @@ func validateEffectiveJSON(data []byte) error {
 			if member.Member == "" {
 				return fmt.Errorf("effective API member %s.%s has empty member type", objectName, member.Name)
 			}
-			if IsScalar(memberType) && !IsScalar(strings.ToLower(member.Member)) {
+			if IsScalar(memberType) && !isSupportedScalarMemberType(memberType, strings.ToLower(member.Member)) {
 				return fmt.Errorf("effective API member %s.%s has unsupported scalar member type %q", objectName, member.Name, member.Member)
 			}
 			if referencesObject(member) && spec.Object(member.Member) == nil {
@@ -474,6 +474,13 @@ func validateEffectiveJSON(data []byte) error {
 		}
 	}
 	return nil
+}
+
+func isSupportedScalarMemberType(valueType, memberType string) bool {
+	if IsScalar(memberType) {
+		return true
+	}
+	return valueType == "string" && memberType == "datetime_iso"
 }
 
 func referencesObject(member Member) bool {

--- a/internal/apimeta/effective_test.go
+++ b/internal/apimeta/effective_test.go
@@ -219,6 +219,13 @@ func TestApplyAPIPatch_AllowsPrimitiveLists(t *testing.T) {
 	}
 }
 
+func TestApplyAPIPatch_AllowsDatetimeISOStringMember(t *testing.T) {
+	patch := `[{"op":"add","path":"/objects/ExistingRequest/members/-","value":{"name":"CreatedAt","type":"string","member":"datetime_iso","required":false}}]`
+	if _, err := apimeta.ApplyAPIPatch([]byte(effectiveTestBase), []byte(patch)); err != nil {
+		t.Fatalf("datetime_iso string member patch returned error: %v", err)
+	}
+}
+
 func TestApplyAPIPatch_RejectsInvalidMemberTypes(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -239,6 +246,11 @@ func TestApplyAPIPatch_RejectsInvalidMemberTypes(t *testing.T) {
 			name:  "unknown scalar member type",
 			value: `{"name":"Count","type":"int","member":"integer"}`,
 			want:  `unsupported scalar member type "integer"`,
+		},
+		{
+			name:  "datetime format on non-string type",
+			value: `{"name":"Count","type":"int","member":"datetime_iso"}`,
+			want:  `unsupported scalar member type "datetime_iso"`,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- accept Tencent Cloud CLI `datetime_iso` member metadata only when the value type is `string`
- keep rejecting `datetime_iso` on non-string values and other unsupported scalar member types
- add regression coverage for both the valid and invalid combinations

## Validation

- `go run ./cmd/internal/apipatch check`
- `go test ./internal/apimeta/... -count=1`
- `go test ./cmd/agr -run TestContract_GeneratedFlagsArePresentOnCobraCommands\|TestContract_RequestFlagOnEveryMappedRequestCommand -count=1`
- `go test ./internal/commands/... -count=1`
- `go run ./cmd/internal/cobragen check`
- `git diff --check`

## Known test environment issue

`go test ./... -count=1` passed every package except `tests/lifecycle`. Its deployment lifecycle uses an existing SandboxTool fixture that currently returns `ResourceNotFound.SandboxTool`; this PR does not change lifecycle or resource behavior.
