### PR TITLE
feat(api): add patch coverage gate and strict verification

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,14 +6,24 @@ Commands run, results, and checks not run:
 
 ## API Patch changes (complete when the candidate contains a non-empty patch)
 
+No live-E2E CI workflow is being added in this phase. Attach a real local E2E
+report or link to it here before merging; CI coverage success is not a substitute.
+For an empty patch, mark this section not applicable rather than inventing evidence.
+
+Report attachment/link:
+
 - [ ] Targets `preview`; canonical `api.json` has not been replaced by a private source.
 - [ ] Source basis and public-disclosure approval recorded (public link or auditable API-owner confirmation; no internal source text).
 - [ ] API version, endpoint/namespace match, SDK/raw-call strategy reviewed.
 - [ ] `apipatch check-all`, `apipatch coverage`, and `cobragen check` pass.
 - [ ] Every obligation maps to real assertions; documentation exemptions reviewed for behavioral constraints.
-- [ ] API owner and CLI maintainer identified and independently approved.
-- [ ] Author strict report and trusted reviewer's independent reproduction match current head/base, source tree and digests.
+- [ ] Required maintainer approval obtained; actual reviewers and roles recorded.
+- [ ] Real E2E report attached or linked: command without credentials, head/base, source tree, patch/plan digests, environment alias, timestamps, scenarios/assertions, pass/fail/skip counts and cleanup results.
+- [ ] Trusted reviewer's independent reproduction matches the report's current source identity and digests.
 - [ ] Cleanup confirmed; responsible owner, review date and upstream-absorption exit condition recorded.
+
+Separate API-owner and CLI-maintainer approvals are optional; independent test
+reproduction and source/disclosure verification remain required.
 
 See [Patch verification](https://github.com/TencentCloudAgentRuntime/ags-cli/blob/main/PATCH-VERIFICATION.md). Reports are manual
 evidence, not an automated authorization gate. A checked box alone is not proof.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,9 @@
 
 <!-- List commands run and their results. Note checks not run and why. -->
 
+<!-- All PRs targeting preview require two approving maintainers with repository
+write access or higher, including sync/documentation PRs. No fixed team is required. -->
+
 <!-- Complete the section below only if the candidate contains a non-empty
 api/ags/**/api.patch.json, even if this PR does not edit that file.
 Otherwise leave it collapsed or remove it; no patch checklist/report is needed. -->
@@ -25,13 +28,16 @@ Report attachment/link:
 - [ ] API version, endpoint/namespace match, SDK/raw-call strategy reviewed.
 - [ ] `apipatch check-all`, `apipatch coverage`, and `cobragen check` pass.
 - [ ] Every obligation maps to real assertions; documentation exemptions reviewed for behavioral constraints.
-- [ ] Required maintainer approval obtained; actual reviewers and roles recorded.
+- [ ] Two different maintainers with repository write access or higher approved the current head; approval links recorded.
+- [ ] Author-nominated API reviewer (not the author) explicitly accepted the API contract; identity and review link recorded, with expertise and conclusions verified by the lead maintainer.
 - [ ] Real E2E report attached or linked: command without credentials, head/base, source tree, patch/plan digests, environment alias, timestamps, scenarios/assertions, pass/fail/skip counts and cleanup results.
 - [ ] Trusted reviewer's independent reproduction matches the report's current source identity and digests.
 - [ ] Cleanup confirmed; responsible owner, review date and upstream-absorption exit condition recorded.
 
-Separate API-owner and CLI-maintainer approvals are optional; independent test
-reproduction and source/disclosure verification remain required.
+The API reviewer need not have repository write access. Without it, their review
+is supporting evidence and does not count toward GitHub's two required approvals.
+The lead maintainer verifies API review, independent test reproduction and
+source/disclosure evidence; no fixed reviewer teams are required.
 
 See [Patch verification](https://github.com/TencentCloudAgentRuntime/ags-cli/blob/main/PATCH-VERIFICATION.md). Reports are manual
 evidence, not an automated authorization gate. A checked box alone is not proof.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,22 @@
 ## Summary
 
+<!-- What changed and why? Link related issues when applicable. -->
+
 ## Verification
 
-Commands run, results, and checks not run:
+<!-- List commands run and their results. Note checks not run and why. -->
 
-## API Patch changes (complete when the candidate contains a non-empty patch)
+<!-- Complete the section below only if the candidate contains a non-empty
+api/ags/**/api.patch.json, even if this PR does not edit that file.
+Otherwise leave it collapsed or remove it; no patch checklist/report is needed. -->
+
+<details>
+<summary>API patch verification — only for non-empty patches</summary>
+
+Complete before merging when the candidate contains a non-empty `api.patch.json`.
 
 No live-E2E CI workflow is being added in this phase. Attach a real local E2E
 report or link to it here before merging; CI coverage success is not a substitute.
-For an empty patch, mark this section not applicable rather than inventing evidence.
 
 Report attachment/link:
 
@@ -27,3 +35,5 @@ reproduction and source/disclosure verification remain required.
 
 See [Patch verification](https://github.com/TencentCloudAgentRuntime/ags-cli/blob/main/PATCH-VERIFICATION.md). Reports are manual
 evidence, not an automated authorization gate. A checked box alone is not proof.
+
+</details>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+
+## Verification
+
+Commands run, results, and checks not run:
+
+## API Patch changes (complete when the candidate contains a non-empty patch)
+
+- [ ] Targets `preview`; canonical `api.json` has not been replaced by a private source.
+- [ ] Source basis and public-disclosure approval recorded (public link or auditable API-owner confirmation; no internal source text).
+- [ ] API version, endpoint/namespace match, SDK/raw-call strategy reviewed.
+- [ ] `apipatch check-all`, `apipatch coverage`, and `cobragen check` pass.
+- [ ] Every obligation maps to real assertions; documentation exemptions reviewed for behavioral constraints.
+- [ ] API owner and CLI maintainer identified and independently approved.
+- [ ] Author strict report and trusted reviewer's independent reproduction match current head/base, source tree and digests.
+- [ ] Cleanup confirmed; responsible owner, review date and upstream-absorption exit condition recorded.
+
+See [Patch verification](https://github.com/TencentCloudAgentRuntime/ags-cli/blob/main/PATCH-VERIFICATION.md). Reports are manual
+evidence, not an automated authorization gate. A checked box alone is not proof.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,17 @@ jobs:
           test -n "$(find "$tmpdocs" -mindepth 1 -maxdepth 1 -type f -print -quit)"
           test -n "$(find "$tmpman" -mindepth 1 -maxdepth 1 -type f -print -quit)"
 
+  patch-coverage:
+    name: Patch Contract Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: Validate complete Patch coverage (no credentials)
+        run: go run ./cmd/internal/apipatch coverage
+
   overlay-smoke:
     name: CLI Overlay Smoke
     runs-on: ubuntu-latest
@@ -246,6 +257,7 @@ jobs:
       - lint
       - changelog-gate
       - generator-gate
+      - patch-coverage
       - overlay-smoke
       - integ-tests
       - release-ready

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,14 @@ jobs:
       - name: Run tests
         run: go test -v -race -coverprofile=coverage.out ./...
 
+      - name: Set up Go 1.26 for archive compatibility
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.x'
+
+      - name: Test archived runner with Go 1.26 (no cloud credentials)
+        run: go test -v -race ./cmd/internal/patch-e2e -count=1
+
       - name: Test one-line installer
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then

--- a/CONTRIBUTING-zh.md
+++ b/CONTRIBUTING-zh.md
@@ -150,9 +150,15 @@ JSON Patch 记录差异；无差异时保持为 `[]`。
 
 ```bash
 go run ./cmd/internal/apipatch check-all
+go run ./cmd/internal/apipatch coverage
 go run ./cmd/internal/apipatch render > /tmp/ags-effective-api.json
 go run ./cmd/internal/cobragen check
 ```
+
+每个有效契约差异必须在 `e2e-coverage.yaml` 中映射到已注册的场景和断言 ID。
+严格入口 `make api-patch-e2e`、提交绑定报告、独立复现、清理及 API owner / CLI
+maintainer 双角色审核前置条件见[补丁验证规范](PATCH-VERIFICATION.md)。
+静态覆盖不代表运行时正确，空 Patch 也不算真实 E2E 通过。
 
 下载新的上游文件后，先不覆盖仓库中的 `api.json`，使用以下命令判定补丁状态：
 

--- a/CONTRIBUTING-zh.md
+++ b/CONTRIBUTING-zh.md
@@ -156,8 +156,11 @@ go run ./cmd/internal/cobragen check
 ```
 
 每个有效契约差异必须在 `e2e-coverage.yaml` 中映射到已注册的场景和断言 ID。
-严格入口 `make api-patch-e2e`、提交绑定报告、独立复现、清理及 API owner / CLI
-maintainer 可选双角色审核见[补丁验证规范](PATCH-VERIFICATION.md)。
+严格入口 `make api-patch-e2e`、提交绑定报告、独立复现、清理及 API 审核见
+[补丁验证规范](PATCH-VERIFICATION.md)。所有合入 `preview` 的 PR 均须获得两位
+具有仓库 write 或更高权限的维护者批准，不绑定固定团队。非空 Patch 的作者还须
+提名一位非本人的 API reviewer，由主审批人核实其身份、相关专业能力和明确同意意见。
+API reviewer 可以没有 write 权限，但此时其意见不计入 GitHub 强制要求的两票。
 静态覆盖不代表运行时正确，空 Patch 也不算真实 E2E 通过。
 
 本阶段不新增真实 E2E 测试流水线。包含非空 Patch 的 PR 必须在合并前附上本地
@@ -259,7 +262,7 @@ docs(readme): 更新安装说明
 ## 审核流程
 
 1. **自动检查**：必需状态检查为 `CI Gate` 和 `gitleaks`。`CI Gate` 聚合 Pull Request 标题与工作流校验、格式、测试、代码检查、变更日志和生成结果校验、Overlay 冒烟测试及发布就绪校验。
-2. **代码审核**：需要至少一位维护者批准
+2. **代码审核**：需要至少一位维护者批准；合入 `preview` 的 PR 须由两位具有仓库 write 或更高权限的维护者批准。
 3. **测试覆盖**：需要足够的测试覆盖率
 4. **文档更新**：如需要则更新文档
 5. **合并**：维护者将合并已批准的 PR

--- a/CONTRIBUTING-zh.md
+++ b/CONTRIBUTING-zh.md
@@ -157,8 +157,12 @@ go run ./cmd/internal/cobragen check
 
 每个有效契约差异必须在 `e2e-coverage.yaml` 中映射到已注册的场景和断言 ID。
 严格入口 `make api-patch-e2e`、提交绑定报告、独立复现、清理及 API owner / CLI
-maintainer 双角色审核前置条件见[补丁验证规范](PATCH-VERIFICATION.md)。
+maintainer 可选双角色审核见[补丁验证规范](PATCH-VERIFICATION.md)。
 静态覆盖不代表运行时正确，空 Patch 也不算真实 E2E 通过。
+
+本阶段不新增真实 E2E 测试流水线。包含非空 Patch 的 PR 必须在合并前附上本地
+真实 E2E 测试报告或报告链接，并由可信 reviewer 独立复跑。空 Patch 的工具类 PR
+无需提供真实 Patch E2E 报告。
 
 下载新的上游文件后，先不覆盖仓库中的 `api.json`，使用以下命令判定补丁状态：
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,9 +155,16 @@ Before submitting a patch change, run:
 
 ```bash
 go run ./cmd/internal/apipatch check-all
+go run ./cmd/internal/apipatch coverage
 go run ./cmd/internal/apipatch render > /tmp/ags-effective-api.json
 go run ./cmd/internal/cobragen check
 ```
+
+Every effective contract delta must map to registered scenario/assertion IDs in
+`e2e-coverage.yaml`. See [Patch verification](PATCH-VERIFICATION.md) for the strict
+`make api-patch-e2e` entrypoint, commit-bound reports, independent reproduction,
+cleanup, and the API-owner/CLI-maintainer approval prerequisites. Static coverage
+does not prove runtime correctness; empty patches do not count as live E2E passes.
 
 After downloading a refreshed upstream file without replacing the checked-in
 copy, classify the patch lifecycle with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,8 +163,12 @@ go run ./cmd/internal/cobragen check
 Every effective contract delta must map to registered scenario/assertion IDs in
 `e2e-coverage.yaml`. See [Patch verification](PATCH-VERIFICATION.md) for the strict
 `make api-patch-e2e` entrypoint, commit-bound reports, independent reproduction,
-cleanup, and the API-owner/CLI-maintainer approval prerequisites. Static coverage
+cleanup, and optional API-owner/CLI-maintainer dual-role review. Static coverage
 does not prove runtime correctness; empty patches do not count as live E2E passes.
+
+No live-E2E CI workflow is being added in this phase. PRs containing a non-empty
+patch must attach or link a real local E2E report before merging, with independent
+reviewer reproduction. Empty-patch tooling PRs do not require a live patch report.
 
 After downloading a refreshed upstream file without replacing the checked-in
 copy, classify the patch lifecycle with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,7 +163,12 @@ go run ./cmd/internal/cobragen check
 Every effective contract delta must map to registered scenario/assertion IDs in
 `e2e-coverage.yaml`. See [Patch verification](PATCH-VERIFICATION.md) for the strict
 `make api-patch-e2e` entrypoint, commit-bound reports, independent reproduction,
-cleanup, and optional API-owner/CLI-maintainer dual-role review. Static coverage
+cleanup, and API review. All PRs targeting `preview` require two different
+approving maintainers with repository write access or higher, without fixed teams.
+For non-empty patches, the author also nominates an API reviewer whose identity,
+expertise and explicit acceptance are verified by the lead maintainer. The API
+reviewer need not have write access, but without it their approval does not count
+toward GitHub's two-vote requirement. Static coverage
 does not prove runtime correctness; empty patches do not count as live E2E passes.
 
 No live-E2E CI workflow is being added in this phase. PRs containing a non-empty
@@ -273,7 +278,7 @@ docs(readme): update installation instructions
 ## Review Process
 
 1. **Automated Checks**: The required status checks are `CI Gate` and `gitleaks`. `CI Gate` aggregates pull request title and workflow validation, formatting, tests, linting, changelog and generated-output validation, overlay smoke tests, and release-readiness validation.
-2. **Code Review**: At least one maintainer approval required
+2. **Code Review**: At least one maintainer approval required; PRs targeting `preview` require two different approving maintainers with repository write access or higher.
 3. **Testing**: Adequate test coverage expected
 4. **Documentation**: Update docs if needed
 5. **Merge**: Maintainers will merge approved PRs

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install go-install clean test lint fmt help man install-man e2e integ
+.PHONY: build install go-install clean test lint fmt help man install-man e2e integ api-patch-coverage api-patch-e2e
 
 # Binary name
 BINARY_NAME=agr
@@ -101,6 +101,14 @@ fmt:
 ## e2e: Run lifecycle tests (requires credentials via env or ~/.agr/config.toml)
 e2e:
 	$(GOTEST) -v -timeout 20m ./tests/lifecycle/...
+
+## api-patch-coverage: Validate complete Patch-to-scenario coverage (no credentials)
+api-patch-coverage:
+	$(GOCMD) run ./cmd/internal/apipatch coverage
+
+## api-patch-e2e: Run strict live Patch scenarios; pass identity flags in ARGS
+api-patch-e2e:
+	@$(GOCMD) run ./cmd/internal/patch-e2e $(ARGS)
 
 ## integ: Run integration tests (no credentials required,<30s)
 integ:

--- a/PATCH-VERIFICATION.md
+++ b/PATCH-VERIFICATION.md
@@ -82,7 +82,8 @@ untracked files make the strict command fail. Do not hide changes with Git
 assume-unchanged/skip-worktree. The launcher rebuilds the test runner (including
 its scenario registry) from a temporary `git archive` of the recorded commit.
 That worker rejects a different head and builds the candidate CLI from the same
-commit. Both builds disable workspace mode and ambient Go flags. Source
+commit. Both builds disable workspace mode, ambient Go flags and automatic VCS
+stamping (`-buildvcs=false`), since the archives have no `.git` metadata. Source
 identity is checked again after testing. The runner itself is candidate code:
 its report is not cryptographically trusted and must be independently reproduced.
 Launcher cancellation forwards an interrupt to the worker for cleanup, with a
@@ -96,6 +97,10 @@ Compare plan digests with `apipatch coverage` on the same source; the public run
 report omits raw contract values and raw CLI output. Review aliases, IDs and review
 rationales for disclosure before posting. Repository/PR/base and environment alias
 are supplied context: reviewers must check them against GitHub and the real account.
+
+Build diagnostics are written to local stderr, separately from the JSON report.
+They may contain source excerpts or local paths: do not combine stderr into the
+public report or publish build logs without a disclosure review.
 
 Missing explicit credentials (for selected live scenarios), unexpected command failures or failed assertions,
 missing assertion execution, skip, panic, cancellation and cleanup failure cannot
@@ -114,22 +119,34 @@ an interrupted/missing report is never usable passing evidence.
 
 ## Reviewer and ownership checklist
 
-Non-empty Patch changes require maintainer approval under the repository's
-normal review rules and independent reproduction as described below. Separate
-API-owner and CLI-maintainer approvals are optional additional protection, not
-a prerequisite for accepting patches. Record actual reviewers and their roles.
+Every PR targeting `preview`, including sync and documentation PRs, requires
+approvals from two different maintainers with repository write access or higher.
+Use GitHub's native required-approval count; no fixed team or separate team quotas
+are required. Record approval links for the current head.
 
-Administrators may add the following protections:
+For a candidate containing a non-empty Patch, the author must also nominate an API
+reviewer other than themselves and link that reviewer's explicit acceptance of the
+API contract. The API reviewer may be any GitHub user; repository write access is
+not required. A lead maintainer must verify the reviewer's relevant expertise,
+identity and conclusions before approving. An external review without write
+access is supporting evidence, not one of GitHub's two required approvals. An API
+reviewer who has write access may also count as one of the two approving maintainers.
 
-- If enabling dual-role review, confirm actual team slugs and repository access.
-- Configure review routing/protection for `api/ags/**`, `internal/patchcoverage/**`,
-  `internal/patchtest/**`, `internal/patchscenarios/**`, `cmd/internal/apipatch/**`,
-  `cmd/internal/patch-e2e/**`, affected generated/runtime files, `Makefile`,
-  `.github/workflows/**`, the PR template and CODEOWNERS itself.
-- If choosing to require both roles, enforce independent approvals with supported
-  rules and validate on a canary PR. CODEOWNERS alone does not enforce both roles.
-- After the real CI job has run, optionally require `Patch Contract Coverage`
-  with GitHub Actions as source; it is already transitively required by CI Gate.
+Administrators must enforce the following on `preview` before accepting non-empty
+Patch candidates:
+
+- Require pull requests and two approving reviews; do not grant bypass access.
+- Dismiss stale approvals on new commits, require approval of the latest reviewable
+  push, and require resolution of review threads.
+- Require `CI Gate` and `gitleaks` from GitHub Actions. `Patch Contract Coverage`
+  is already transitively required by `CI Gate`.
+- Validate with canary PRs: one eligible approval, an external approval plus only
+  one eligible approval, and stale approvals must not satisfy the two-vote gate.
+  Two eligible approvals satisfy only the approval count, not the other merge checks.
+
+GitHub enforces the approval count, not API expertise or evidence quality. The
+lead maintainer must check API review, source/disclosure verification, the real
+E2E report and independent reproduction before approving and merging.
 
 Author report is supporting evidence. A trusted reviewer must independently rerun
 the strict command on the exact source in an isolated environment, then compare

--- a/PATCH-VERIFICATION.md
+++ b/PATCH-VERIFICATION.md
@@ -7,6 +7,23 @@ real API tests require a separate, reviewed local run.
 `api.json` is canonical; a passing test does not turn `api.patch.json` into an
 official contract. Non-empty patches belong only on `preview`.
 
+## Required evidence
+
+No live-E2E CI workflow is being added in this phase. CI automatically checks
+coverage mappings without cloud credentials; it does not run real API tests or
+verify that a report has been attached. Reviewers enforce the evidence requirement.
+
+Every PR whose candidate contains a non-empty `api.patch.json` must attach a
+real E2E report, or link to it from the PR description, before merging. Run the
+strict command below locally against the real backend in an isolated test
+environment. Include the exact command (without credentials), current head/base
+SHAs, source tree, patch/plan digests, environment alias, timestamps, executed
+scenarios/assertions, pass/fail/skip counts and confirmed cleanup results.
+Mocks, coverage mappings and checked boxes are not substitutes for this report.
+
+PRs with empty patches, including changes to verification tooling itself, do not
+require a real patch-E2E report. State that no live patch behavior was tested.
+
 ## Author workflow
 
 1. Run `go run ./cmd/internal/apipatch delta` to derive all current changes in
@@ -34,7 +51,7 @@ official contract. Non-empty patches belong only on `preview`.
    ```
 
 4. Documentation-only entries may instead have a nonempty `review` rationale.
-   **Prose can encode enums or constraints.** API owner must review every such
+   **Prose can encode enums or constraints.** The reviewer must review every such
    exemption; use scenario/assertion mapping instead when the prose changes a
    behavioral promise. `document`/`example` classification is not an automatic
    claim that live testing is unnecessary.
@@ -97,18 +114,20 @@ an interrupted/missing report is never usable passing evidence.
 
 ## Reviewer and ownership checklist
 
-Both an API owner and a CLI maintainer must approve non-empty Patch changes.
-Record actual reviewers and their roles; do not assume one code-owner approval
-means both roles approved. Administrators must verify the following protections
-before accepting non-empty patches:
+Non-empty Patch changes require maintainer approval under the repository's
+normal review rules and independent reproduction as described below. Separate
+API-owner and CLI-maintainer approvals are optional additional protection, not
+a prerequisite for accepting patches. Record actual reviewers and their roles.
 
-- Confirm actual API-owner and CLI-maintainer team slugs and repository access.
+Administrators may add the following protections:
+
+- If enabling dual-role review, confirm actual team slugs and repository access.
 - Configure review routing/protection for `api/ags/**`, `internal/patchcoverage/**`,
   `internal/patchtest/**`, `internal/patchscenarios/**`, `cmd/internal/apipatch/**`,
   `cmd/internal/patch-e2e/**`, affected generated/runtime files, `Makefile`,
   `.github/workflows/**`, the PR template and CODEOWNERS itself.
-- Enforce independent dual-role approvals with supported rules, and validate on
-  a canary PR. CODEOWNERS entries alone do not prove that both roles are required.
+- If choosing to require both roles, enforce independent approvals with supported
+  rules and validate on a canary PR. CODEOWNERS alone does not enforce both roles.
 - After the real CI job has run, optionally require `Patch Contract Coverage`
   with GitHub Actions as source; it is already transitively required by CI Gate.
 
@@ -121,8 +140,8 @@ behavior causes failure. Without independent reproduction, do not merge.
 New head commits invalidate approvals/reports. Base changes require comparing the
 new candidate merge result and rerunning when it changes. The local runner records
 identity but does not automatically query GitHub or publish a trusted check.
-Do not require a live-E2E status check unless an authorized CI workflow exists
-and its security controls have been tested.
+No live-E2E status check is required in this phase. Any future automation needs
+a separate design and security review; it is not a prerequisite for this workflow.
 
 Record public source/disclosure approval, API version and endpoint/namespace
 match, SDK or raw-call strategy, API owner, cleanup owner, expiry/review date and

--- a/PATCH-VERIFICATION.md
+++ b/PATCH-VERIFICATION.md
@@ -1,0 +1,134 @@
+# API Patch Verification Guide
+
+Use this guide to map API patch changes to tests, produce local verification
+reports, and review the evidence before merging. CI checks coverage mappings;
+real API tests require a separate, reviewed local run.
+
+`api.json` is canonical; a passing test does not turn `api.patch.json` into an
+official contract. Non-empty patches belong only on `preview`.
+
+## Author workflow
+
+1. Run `go run ./cmd/internal/apipatch delta` to derive all current changes in
+   every API version, not just the lines changed in this PR. Member names, rather
+   than array positions, identify obligations. Added/removed entities include an
+   `@exists` obligation as well as their individual properties. Unknown metadata
+   changes fail closed and require an explicit classifier change with tests.
+   The existing patch engine rejects `move`/`copy`; this tool does not expand it.
+2. Register a real CLI scenario in `internal/patchscenarios`, with stable scenario
+   and assertion IDs. Use `patchtest.Session.CLI` to invoke the candidate binary.
+   Test request values, response shape, readback where available, and meaningful
+   boundary/error behavior. Do not replace these checks with `exit == 0` alone.
+3. Map each entry in `api/ags/<version>/e2e-coverage.yaml`. Copy the part following
+   `#` in the delta's ID. Each entry maps to one scenario and one or more assertion
+   IDs; one scenario can satisfy many entries. Repeated, stale, missing and unknown
+   mappings fail. To cover an entry with multiple behaviors, use distinct required
+   assertion IDs in the same scenario.
+
+   ```yaml
+   version: 1
+   coverage:
+     - entry: /objects/ExampleRequest/members/Limit/required
+       scenario: example.lifecycle
+       assertions: [limit.readback, limit.boundary]
+   ```
+
+4. Documentation-only entries may instead have a nonempty `review` rationale.
+   **Prose can encode enums or constraints.** API owner must review every such
+   exemption; use scenario/assertion mapping instead when the prose changes a
+   behavioral promise. `document`/`example` classification is not an automatic
+   claim that live testing is unnecessary.
+5. Run `make api-patch-coverage`. CI always runs `Patch Contract Coverage`, even
+   for empty patches, and includes it in `CI Gate`. Empty entries mean there is
+   no runtime obligation, not that any live behavior was tested.
+
+## Strict execution and evidence
+
+Only after reviewing the candidate code, use a disposable, isolated environment
+and a dedicated least-privilege cloud test account. An isolated CLI home prevents
+accidental config reuse; it is **not a security sandbox** for candidate Go code.
+Do not run arbitrary PR code on a privileged maintainer laptop or inject release
+credentials/repository-write tokens. The local runner does not authorize or
+trigger live tests in GitHub Actions.
+
+From a clean checkout of the exact PR head (fetch the exact base commit too):
+
+```bash
+# Set TENCENTCLOUD_SECRET_ID, TENCENTCLOUD_SECRET_KEY, AGR_REGION via your
+# credential provider; set TENCENTCLOUD_TOKEN for temporary STS credentials.
+# Optional AGR_CLOUD_ENDPOINT / AGR_DOMAIN must be reviewed for the target API.
+make api-patch-e2e ARGS="--repository TencentCloudAgentRuntime/ags-cli --pr 123 --head <full-head-sha> --base <full-base-sha> --environment disposable-test" > /tmp/patch-e2e-report.json
+```
+
+Use a **new report path per run** outside the checkout. Staged, unstaged and
+untracked files make the strict command fail. Do not hide changes with Git
+assume-unchanged/skip-worktree. The launcher rebuilds the test runner (including
+its scenario registry) from a temporary `git archive` of the recorded commit.
+That worker rejects a different head and builds the candidate CLI from the same
+commit. Both builds disable workspace mode and ambient Go flags. Source
+identity is checked again after testing. The runner itself is candidate code:
+its report is not cryptographically trusted and must be independently reproduced.
+Launcher cancellation forwards an interrupt to the worker for cleanup, with a
+three-minute grace period before forced termination.
+
+Report fields include repository/PR, full head/base and tested commit/tree,
+path-and-content Patch digest across all versions, plan digest, entrypoint version,
+environment alias, timestamps, results, assertion IDs, CLI call counts and per-case
+cleanup status. Digests use SHA-256 over sorted length-prefixed path/content pairs.
+Compare plan digests with `apipatch coverage` on the same source; the public runtime
+report omits raw contract values and raw CLI output. Review aliases, IDs and review
+rationales for disclosure before posting. Repository/PR/base and environment alias
+are supplied context: reviewers must check them against GitHub and the real account.
+
+Missing explicit credentials (for selected live scenarios), unexpected command failures or failed assertions,
+missing assertion execution, skip, panic, cancellation and cleanup failure cannot
+produce a passing run. Scenarios must propagate relevant CLI errors. Even if an
+assertion's returned error is ignored, a failed assertion poisons the scenario.
+Empty/documentation-only plans return `not_applicable`, never live `pass`.
+
+Each scenario must register cleanup immediately for every created resource,
+including partial-failure IDs. Cleanup callbacks must **confirm absence**, not
+merely accept an asynchronous delete response. All registered callbacks run in
+reverse order after success/failure/panic, each with a fresh two-minute timeout.
+A read-only case explicitly calls `NoResources()`; missing cleanup declarations
+fail. Reviewer must audit that declarations cover every resource. Hard kill,
+machine loss and hung scenario code still require external TTL/janitor cleanup;
+an interrupted/missing report is never usable passing evidence.
+
+## Reviewer and ownership checklist
+
+Both an API owner and a CLI maintainer must approve non-empty Patch changes.
+Record actual reviewers and their roles; do not assume one code-owner approval
+means both roles approved. Administrators must verify the following protections
+before accepting non-empty patches:
+
+- Confirm actual API-owner and CLI-maintainer team slugs and repository access.
+- Configure review routing/protection for `api/ags/**`, `internal/patchcoverage/**`,
+  `internal/patchtest/**`, `internal/patchscenarios/**`, `cmd/internal/apipatch/**`,
+  `cmd/internal/patch-e2e/**`, affected generated/runtime files, `Makefile`,
+  `.github/workflows/**`, the PR template and CODEOWNERS itself.
+- Enforce independent dual-role approvals with supported rules, and validate on
+  a canary PR. CODEOWNERS entries alone do not prove that both roles are required.
+- After the real CI job has run, optionally require `Patch Contract Coverage`
+  with GitHub Actions as source; it is already transitively required by CI Gate.
+
+Author report is supporting evidence. A trusted reviewer must independently rerun
+the strict command on the exact source in an isolated environment, then compare
+identity, plan, assertion records and cleanup. Scenario/entry set equality only
+proves bookkeeping; review the assertions themselves and show a targeted wrong
+behavior causes failure. Without independent reproduction, do not merge.
+
+New head commits invalidate approvals/reports. Base changes require comparing the
+new candidate merge result and rerunning when it changes. The local runner records
+identity but does not automatically query GitHub or publish a trusted check.
+Do not require a live-E2E status check unless an authorized CI workflow exists
+and its security controls have been tested.
+
+Record public source/disclosure approval, API version and endpoint/namespace
+match, SDK or raw-call strategy, API owner, cleanup owner, expiry/review date and
+official-absorption exit condition in each Patch PR. Do not paste internal source
+text, credentials, tenant IDs, private endpoints or raw sensitive responses into
+public GitHub. Use an auditable API-owner confirmation for nonpublic sources.
+
+Real patch scenarios belong with the preview-only capabilities they verify.
+Do not add fabricated passing scenarios to populate an otherwise empty registry.

--- a/api/ags/v20250920/e2e-coverage.yaml
+++ b/api/ags/v20250920/e2e-coverage.yaml
@@ -1,0 +1,2 @@
+version: 1
+coverage: []

--- a/cmd/internal/apipatch/main.go
+++ b/cmd/internal/apipatch/main.go
@@ -14,6 +14,8 @@ import (
 	"slices"
 
 	"github.com/TencentCloudAgentRuntime/ags-cli/internal/apimeta"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/patchcoverage"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/patchscenarios"
 )
 
 const defaultAPIDir = "api/ags/v20250920"
@@ -27,9 +29,23 @@ func main() {
 
 func run(args []string, stdout io.Writer) error {
 	if len(args) == 0 {
-		return fmt.Errorf("usage: apipatch <check|check-all|render|rebase> [flags]")
+		return fmt.Errorf("usage: apipatch <check|check-all|render|rebase|delta|coverage> [flags]")
 	}
 	switch args[0] {
+	case "coverage", "delta":
+		flags := flag.NewFlagSet(args[0], flag.ContinueOnError)
+		root := flags.String("root", ".", "repository root")
+		if err := flags.Parse(args[1:]); err != nil {
+			return err
+		}
+		if flags.NArg() != 0 {
+			return fmt.Errorf("unexpected positional arguments")
+		}
+		plan, err := patchcoverage.Load(*root, patchscenarios.Registry.Coverage(), args[0] == "coverage")
+		if err != nil {
+			return err
+		}
+		return json.NewEncoder(stdout).Encode(plan)
 	case "check":
 		return runCheck(args[1:], stdout)
 	case "check-all":
@@ -39,7 +55,7 @@ func run(args []string, stdout io.Writer) error {
 	case "rebase":
 		return runRebase(args[1:], stdout)
 	default:
-		return fmt.Errorf("unknown subcommand %q (allowed: check, check-all, render, rebase)", args[0])
+		return fmt.Errorf("unknown subcommand %q (allowed: check, check-all, render, rebase, delta, coverage)", args[0])
 	}
 }
 

--- a/cmd/internal/patch-e2e/archive_test.go
+++ b/cmd/internal/patch-e2e/archive_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"os/exec"
@@ -90,9 +91,13 @@ func init() { Registry["fixture"] = patchtest.Scenario{Assertions: []string{"beh
 	t.Setenv("TENCENTCLOUD_SECRET_ID", "fixture-only")
 	t.Setenv("TENCENTCLOUD_SECRET_KEY", "fixture-only")
 	t.Setenv("AGR_REGION", "fixture")
+	var diagnostics bytes.Buffer
 	runBinary := func(binary, head string) (Report, error) {
 		t.Helper()
-		b, err := exec.CommandContext(t.Context(), binary, "--repository", "example/repo", "--pr", "1", "--head", head, "--base", headA, "--environment", "fixture").Output()
+		diagnostics.Reset()
+		cmd := exec.CommandContext(t.Context(), binary, "--repository", "example/repo", "--pr", "1", "--head", head, "--base", headA, "--environment", "fixture")
+		cmd.Stderr = &diagnostics
+		b, err := cmd.Output()
 		var report Report
 		if e := json.Unmarshal(b, &report); e != nil {
 			t.Fatalf("report: %s %v (process: %v)", b, e, err)
@@ -111,5 +116,23 @@ func init() { Registry["fixture"] = patchtest.Scenario{Assertions: []string{"beh
 	}
 	if r, err := runBinary(launcher, headB); err == nil || r.Status != "fail" || r.Failed != 1 || r.Source != headB {
 		t.Fatalf("launcher did not execute new committed assertion: %+v %v", r, err)
+	}
+	// Both archive builds must preserve compiler diagnostics on stderr only,
+	// including the candidate build performed inside the launcher child process.
+	for _, fixture := range []struct{ path, reason string }{
+		{"cmd/agr/main.go", "committed runner failed: candidate CLI build failed"},
+		{"cmd/internal/patch-e2e/broken.go", "committed runner build failed"},
+	} {
+		write(fixture.path, "package main\nvar _ = archiveBuildDiagnosticMarker\n")
+		command("git", "add", fixture.path)
+		command("git", "commit", "-m", "invalid-build-fixture")
+		head := command("git", "rev-parse", "HEAD")
+		r, err := runBinary(launcher, head)
+		if err == nil || r.Status != "fail" || r.Reason != fixture.reason {
+			t.Fatalf("build failure report: %+v %v", r, err)
+		}
+		if !strings.Contains(diagnostics.String(), "undefined: archiveBuildDiagnosticMarker") {
+			t.Fatalf("missing compiler diagnostic: %s", &diagnostics)
+		}
 	}
 }

--- a/cmd/internal/patch-e2e/archive_test.go
+++ b/cmd/internal/patch-e2e/archive_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// All child processes use a local CLI fixture, never a cloud endpoint.
+func TestArchivedRunnerUsesCommittedScenarios(t *testing.T) {
+	source, err := filepath.Abs("../../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	for _, dir := range []string{"cmd/internal/patch-e2e", "internal/apimeta", "internal/patchcoverage", "internal/patchtest", "internal/patchscenarios"} {
+		if err := os.CopyFS(filepath.Join(root, dir), os.DirFS(filepath.Join(source, dir))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write := func(path, data string) {
+		t.Helper()
+		path = filepath.Join(root, path)
+		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(data), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, name := range []string{"go.mod", "go.sum"} {
+		data, err := os.ReadFile(filepath.Join(source, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		write(name, string(data))
+	}
+	write("cmd/agr/main.go", "package main\nfunc main() {}\n")
+	write("api/ags/v1/api.json", `{"actions":{},"objects":{"Req":{"members":[]}}}`)
+	write("api/ags/v1/api.patch.json", `[{"op":"add","path":"/objects/Req/type","value":"object"}]`)
+	write("api/ags/v1/e2e-coverage.yaml", "version: 1\ncoverage:\n  - entry: /objects/Req/type\n    scenario: fixture\n    assertions: [behavior]\n")
+	registry := `package patchscenarios
+import "github.com/TencentCloudAgentRuntime/ags-cli/internal/patchtest"
+var Registry = patchtest.Registry{"fixture": {Assertions: []string{"behavior"}, Run: func(s *patchtest.Session) error {
+ s.NoResources()
+ if _, err := s.CLI(s.Context); err != nil { return err }
+ return s.Assert("behavior", true)
+}}}
+`
+	write("internal/patchscenarios/registry.go", registry)
+	write(".gitignore", "internal/patchscenarios/ignored.go\n")
+	t.Chdir(root)
+	t.Setenv("GOWORK", "off")
+	t.Setenv("GOFLAGS", "")
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	t.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+	command := func(name string, args ...string) string {
+		t.Helper()
+		b, err := exec.CommandContext(t.Context(), name, args...).CombinedOutput()
+		if err != nil {
+			t.Fatalf("%s: %s %v", name, b, err)
+		}
+		return strings.TrimSpace(string(b))
+	}
+	command("git", "init")
+	command("git", "config", "user.email", "fixture@example.com")
+	command("git", "config", "user.name", "Fixture")
+	command("git", "config", "commit.gpgsign", "false")
+	command("git", "add", ".")
+	command("git", "commit", "-m", "passing-scenario")
+	headA := command("git", "rev-parse", "HEAD")
+	binDir := t.TempDir()
+	launcher := filepath.Join(binDir, "launcher")
+	worker := filepath.Join(binDir, "worker")
+	command("go", "build", "-o", worker, "-ldflags=-X main.runnerCommit="+headA, "./cmd/internal/patch-e2e")
+	// The launcher itself includes ignored source. It must still execute the
+	// archived registry, not this locally replaced assertion.
+	write("internal/patchscenarios/ignored.go", `package patchscenarios
+import "github.com/TencentCloudAgentRuntime/ags-cli/internal/patchtest"
+func init() { Registry["fixture"] = patchtest.Scenario{Assertions: []string{"behavior"}, Run: func(s *patchtest.Session) error {
+ s.NoResources()
+ if _, err := s.CLI(s.Context); err != nil { return err }
+ return s.Assert("behavior", false)
+}} }
+`)
+	command("go", "build", "-o", launcher, "./cmd/internal/patch-e2e")
+	t.Setenv("TENCENTCLOUD_SECRET_ID", "fixture-only")
+	t.Setenv("TENCENTCLOUD_SECRET_KEY", "fixture-only")
+	t.Setenv("AGR_REGION", "fixture")
+	runBinary := func(binary, head string) (Report, error) {
+		t.Helper()
+		b, err := exec.CommandContext(t.Context(), binary, "--repository", "example/repo", "--pr", "1", "--head", head, "--base", headA, "--environment", "fixture").Output()
+		var report Report
+		if e := json.Unmarshal(b, &report); e != nil {
+			t.Fatalf("report: %s %v (process: %v)", b, e, err)
+		}
+		return report, err
+	}
+	if r, err := runBinary(launcher, headA); err != nil || r.Status != "pass" {
+		t.Fatalf("ignored source contaminated archived runner: %+v %v", r, err)
+	}
+	write("internal/patchscenarios/registry.go", strings.Replace(registry, `s.Assert("behavior", true)`, `s.Assert("behavior", false)`, 1))
+	command("git", "add", "internal/patchscenarios/registry.go")
+	command("git", "commit", "-m", "failing-scenario-same-IDs")
+	headB := command("git", "rev-parse", "HEAD")
+	if r, err := runBinary(worker, headB); err == nil || !strings.Contains(r.Reason, "runner commit") {
+		t.Fatalf("old worker accepted new head: %+v %v", r, err)
+	}
+	if r, err := runBinary(launcher, headB); err == nil || r.Status != "fail" || r.Failed != 1 || r.Source != headB {
+		t.Fatalf("launcher did not execute new committed assertion: %+v %v", r, err)
+	}
+}

--- a/cmd/internal/patch-e2e/main.go
+++ b/cmd/internal/patch-e2e/main.go
@@ -1,0 +1,263 @@
+// Command patch-e2e produces local, commit-bound evidence, not a trusted CI check.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/patchcoverage"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/patchscenarios"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/patchtest"
+)
+
+const entrypointVersion = "patch-e2e/v1"
+
+// Set only when building the worker from a committed archive. An ordinary
+// go run/build produces a launcher, which rebuilds the worker before testing.
+var runnerCommit string
+
+type Report struct {
+	Version     string             `json:"entrypoint_version"`
+	Repository  string             `json:"repository"`
+	PR          int                `json:"pr"`
+	Head        string             `json:"head_sha"`
+	Base        string             `json:"base_sha"`
+	Source      string             `json:"source_commit"`
+	Tree        string             `json:"source_tree"`
+	Environment string             `json:"environment"`
+	Started     time.Time          `json:"started"`
+	Finished    time.Time          `json:"finished"`
+	Status      string             `json:"status"`
+	Reason      string             `json:"reason,omitempty"`
+	Plan        patchcoverage.Plan `json:"plan"`
+	Results     []patchtest.Result `json:"results"`
+	Passed      int                `json:"pass"`
+	Failed      int                `json:"fail"`
+	Skipped     int                `json:"skip"`
+}
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	ctx, cancel := context.WithTimeout(ctx, 20*time.Minute)
+	defer cancel()
+	if err := run(ctx, os.Args[1:], os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, "patch-e2e:", err)
+		os.Exit(1)
+	}
+}
+
+func git(ctx context.Context, args ...string) (string, error) {
+	b, err := exec.CommandContext(ctx, "git", args...).Output()
+	if err != nil {
+		return "", fmt.Errorf("git identity check failed")
+	}
+	return strings.TrimSpace(string(b)), nil
+}
+
+func run(ctx context.Context, args []string, out io.Writer) (retErr error) {
+	r := Report{Version: entrypointVersion, Started: time.Now().UTC(), Status: "fail"}
+	f := flag.NewFlagSet("patch-e2e", flag.ContinueOnError)
+	f.StringVar(&r.Repository, "repository", "", "public owner/repository")
+	f.IntVar(&r.PR, "pr", 0, "pull request number")
+	f.StringVar(&r.Head, "head", "", "exact PR head SHA; must equal checked-out HEAD")
+	f.StringVar(&r.Base, "base", "", "exact PR base SHA")
+	f.StringVar(&r.Environment, "environment", "", "non-sensitive test environment alias")
+	if err := f.Parse(args); err != nil {
+		return err
+	}
+	defer func() {
+		r.Finished = time.Now().UTC()
+		if retErr != nil {
+			r.Status = "fail"
+			r.Reason = retErr.Error()
+		}
+		// Contract values are review material, not public execution evidence.
+		r.Plan.Entries = nil
+		data, err := patchtest.EncodeReport(r)
+		if err == nil {
+			_, err = fmt.Fprintln(out, string(data))
+		}
+		if err != nil {
+			retErr = fmt.Errorf("write evidence report failed")
+		}
+	}()
+	sha := regexp.MustCompile(`^[0-9a-f]{40}$`)
+	if f.NArg() != 0 || !regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`).MatchString(r.Repository) || r.PR <= 0 || !sha.MatchString(r.Head) || !sha.MatchString(r.Base) || !regexp.MustCompile(`^[A-Za-z0-9_-]{1,64}$`).MatchString(r.Environment) {
+		return fmt.Errorf("repository, pr, full head/base SHAs and a safe environment alias are required")
+	}
+	root, err := git(ctx, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return err
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("cannot determine working directory")
+	}
+	if cwd != root {
+		return fmt.Errorf("run from the repository root")
+	}
+	if err := clean(ctx, r.Head); err != nil {
+		return err
+	}
+	if runnerCommit != "" && runnerCommit != r.Head {
+		return fmt.Errorf("runner commit does not match requested head; rebuild the launcher")
+	}
+	r.Source = r.Head
+	r.Tree, err = git(ctx, "rev-parse", "HEAD^{tree}")
+	if err != nil {
+		return err
+	}
+	base, err := git(ctx, "rev-parse", "--verify", r.Base+"^{commit}")
+	if err != nil || base != r.Base {
+		return fmt.Errorf("base commit unavailable locally")
+	}
+	if runnerCommit == "" {
+		tmp, err := os.MkdirTemp("", "agr-patch-runner-")
+		if err != nil {
+			return fmt.Errorf("create runner directory failed")
+		}
+		defer func() {
+			if os.RemoveAll(tmp) != nil {
+				retErr = fmt.Errorf("runner artifact cleanup failed")
+			}
+		}()
+		if err := extractCommit(ctx, r.Source, tmp); err != nil {
+			return err
+		}
+		binary := filepath.Join(tmp, "patch-e2e-worker")
+		build := exec.CommandContext(ctx, "go", "build", "-mod=readonly", "-ldflags=-X main.runnerCommit="+r.Source, "-o", binary, "./cmd/internal/patch-e2e")
+		build.Dir = tmp
+		build.Env = append(os.Environ(), "GOWORK=off", "GOFLAGS=")
+		if build.Run() != nil {
+			return fmt.Errorf("committed runner build failed")
+		}
+		worker := exec.CommandContext(ctx, binary, args...)
+		// Forward cancellation so the worker can run resource cleanup before
+		// a bounded forced termination, rather than killing it immediately.
+		worker.Cancel = func() error { return worker.Process.Signal(os.Interrupt) }
+		worker.WaitDelay = 3 * time.Minute
+		data, runErr := worker.Output()
+		if err := json.Unmarshal(data, &r); err != nil {
+			return fmt.Errorf("committed runner did not produce a valid report")
+		}
+		if runErr != nil {
+			return fmt.Errorf("committed runner failed: %s", r.Reason)
+		}
+		return clean(ctx, r.Head)
+	}
+	r.Plan, err = patchcoverage.Load(root, patchscenarios.Registry.Coverage(), true)
+	if err != nil {
+		return fmt.Errorf("coverage validation failed; run apipatch coverage for details")
+	}
+	if len(r.Plan.Entries) == 0 {
+		r.Status = "not_applicable"
+		return nil
+	}
+	live := false
+	for _, b := range r.Plan.Bindings {
+		if b.Scenario != "" {
+			live = true
+		}
+	}
+	if !live {
+		r.Status = "not_applicable"
+		return nil
+	}
+	if strings.TrimSpace(os.Getenv("TENCENTCLOUD_SECRET_ID")) == "" || strings.TrimSpace(os.Getenv("TENCENTCLOUD_SECRET_KEY")) == "" || strings.TrimSpace(os.Getenv("AGR_REGION")) == "" {
+		return fmt.Errorf("explicit test credentials and AGR_REGION are required")
+	}
+	// Build only tracked committed source in a temporary extraction; ignored
+	// local Go files or concurrent edits cannot change the candidate binary.
+	tmp, err := os.MkdirTemp("", "agr-patch-e2e-")
+	if err != nil {
+		return fmt.Errorf("create build directory failed")
+	}
+	defer func() {
+		if os.RemoveAll(tmp) != nil {
+			retErr = fmt.Errorf("local artifact cleanup failed")
+		}
+	}()
+	if err := extractCommit(ctx, r.Source, tmp); err != nil {
+		return err
+	}
+	binary := filepath.Join(tmp, "agr-candidate")
+	build := exec.CommandContext(ctx, "go", "build", "-mod=readonly", "-o", binary, "./cmd/agr")
+	build.Dir = tmp
+	build.Env = append(os.Environ(), "GOWORK=off", "GOFLAGS=")
+	if build.Run() != nil {
+		return fmt.Errorf("candidate CLI build failed")
+	}
+	home := filepath.Join(tmp, "test-home")
+	if os.Mkdir(home, 0700) != nil {
+		return fmt.Errorf("create isolated CLI home failed")
+	}
+	env := []string{"HOME=" + home, "USERPROFILE=" + home, "PATH=" + os.Getenv("PATH")}
+	for _, key := range []string{"TENCENTCLOUD_SECRET_ID", "TENCENTCLOUD_SECRET_KEY", "TENCENTCLOUD_TOKEN", "AGR_REGION", "AGR_CLOUD_ENDPOINT", "AGR_DOMAIN"} {
+		if v := os.Getenv(key); v != "" {
+			env = append(env, key+"="+v)
+		}
+	}
+	r.Results, err = patchtest.Run(ctx, r.Plan, patchscenarios.Registry, binary, env)
+	for _, result := range r.Results {
+		switch result.Status {
+		case "pass":
+			r.Passed++
+		case "skip":
+			r.Skipped++
+		default:
+			r.Failed++
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("live scenarios failed; inspect status and cleanup records")
+	}
+	if err := clean(ctx, r.Head); err != nil {
+		return err
+	}
+	r.Status = "pass"
+	return nil
+}
+
+func extractCommit(ctx context.Context, commit, dir string) error {
+	archive := exec.CommandContext(ctx, "git", "archive", "--format=tar", commit)
+	reader, err := archive.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("archive source failed")
+	}
+	if err := archive.Start(); err != nil {
+		return fmt.Errorf("archive source failed")
+	}
+	extract := exec.CommandContext(ctx, "tar", "-xf", "-", "-C", dir)
+	extract.Stdin = reader
+	extractErr := extract.Run()
+	_ = reader.Close()
+	archiveErr := archive.Wait()
+	if extractErr != nil || archiveErr != nil {
+		return fmt.Errorf("extract committed source failed")
+	}
+	return nil
+}
+
+func clean(ctx context.Context, head string) error {
+	current, err := git(ctx, "rev-parse", "HEAD")
+	if err != nil || current != head {
+		return fmt.Errorf("head SHA does not match checked-out source")
+	}
+	status, err := git(ctx, "status", "--porcelain", "--untracked-files=all")
+	if err != nil || status != "" {
+		return fmt.Errorf("a clean worktree including untracked files is required")
+	}
+	return nil
+}

--- a/cmd/internal/patch-e2e/main.go
+++ b/cmd/internal/patch-e2e/main.go
@@ -52,7 +52,7 @@ func main() {
 	defer stop()
 	ctx, cancel := context.WithTimeout(ctx, 20*time.Minute)
 	defer cancel()
-	if err := run(ctx, os.Args[1:], os.Stdout); err != nil {
+	if err := run(ctx, os.Args[1:], os.Stdout, os.Stderr); err != nil {
 		fmt.Fprintln(os.Stderr, "patch-e2e:", err)
 		os.Exit(1)
 	}
@@ -66,7 +66,7 @@ func git(ctx context.Context, args ...string) (string, error) {
 	return strings.TrimSpace(string(b)), nil
 }
 
-func run(ctx context.Context, args []string, out io.Writer) (retErr error) {
+func run(ctx context.Context, args []string, out, diagnostics io.Writer) (retErr error) {
 	r := Report{Version: entrypointVersion, Started: time.Now().UTC(), Status: "fail"}
 	f := flag.NewFlagSet("patch-e2e", flag.ContinueOnError)
 	f.StringVar(&r.Repository, "repository", "", "public owner/repository")
@@ -143,13 +143,16 @@ func run(ctx context.Context, args []string, out io.Writer) (retErr error) {
 			return err
 		}
 		binary := filepath.Join(tmp, "patch-e2e-worker")
-		build := exec.CommandContext(ctx, "go", "build", "-mod=readonly", "-ldflags=-X main.runnerCommit="+r.Source, "-o", binary, "./cmd/internal/patch-e2e")
+		// The archive has no Git metadata; identity is bound explicitly above.
+		build := exec.CommandContext(ctx, "go", "build", "-buildvcs=false", "-mod=readonly", "-ldflags=-X main.runnerCommit="+r.Source, "-o", binary, "./cmd/internal/patch-e2e")
 		build.Dir = tmp
 		build.Env = append(os.Environ(), "GOWORK=off", "GOFLAGS=")
+		build.Stderr = diagnostics
 		if build.Run() != nil {
 			return fmt.Errorf("committed runner build failed")
 		}
 		worker := exec.CommandContext(ctx, binary, args...)
+		worker.Stderr = diagnostics
 		// Forward cancellation so the worker can run resource cleanup before
 		// a bounded forced termination, rather than killing it immediately.
 		worker.Cancel = func() error { return worker.Process.Signal(os.Interrupt) }
@@ -199,9 +202,10 @@ func run(ctx context.Context, args []string, out io.Writer) (retErr error) {
 		return err
 	}
 	binary := filepath.Join(tmp, "agr-candidate")
-	build := exec.CommandContext(ctx, "go", "build", "-mod=readonly", "-o", binary, "./cmd/agr")
+	build := exec.CommandContext(ctx, "go", "build", "-buildvcs=false", "-mod=readonly", "-o", binary, "./cmd/agr")
 	build.Dir = tmp
 	build.Env = append(os.Environ(), "GOWORK=off", "GOFLAGS=")
+	build.Stderr = diagnostics
 	if build.Run() != nil {
 		return fmt.Errorf("candidate CLI build failed")
 	}

--- a/cmd/internal/patch-e2e/main.go
+++ b/cmd/internal/patch-e2e/main.go
@@ -101,11 +101,17 @@ func run(ctx context.Context, args []string, out io.Writer) (retErr error) {
 	if err != nil {
 		return err
 	}
-	cwd, err := os.Getwd()
+	cwd, err := os.Stat(".")
 	if err != nil {
 		return fmt.Errorf("cannot determine working directory")
 	}
-	if cwd != root {
+	repoRoot, err := os.Stat(root)
+	if err != nil {
+		return fmt.Errorf("cannot determine repository root")
+	}
+	// macOS temporary directories can have both logical and physical paths.
+	// Compare directory identity so aliases work without accepting subdirectories.
+	if !os.SameFile(cwd, repoRoot) {
 		return fmt.Errorf("run from the repository root")
 	}
 	if err := clean(ctx, r.Head); err != nil {

--- a/cmd/internal/patch-e2e/main_test.go
+++ b/cmd/internal/patch-e2e/main_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/patchscenarios"
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/patchtest"
+)
+
+func TestStrictPreflight(t *testing.T) {
+	oldCommit := runnerCommit
+	t.Cleanup(func() { runnerCommit = oldCommit })
+	root := t.TempDir()
+	t.Chdir(root)
+	gitRun := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null")
+		b, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git fixture: %s %v", b, err)
+		}
+		return strings.TrimSpace(string(b))
+	}
+	gitRun("init")
+	gitRun("config", "user.email", "fixture@example.com")
+	gitRun("config", "user.name", "Fixture")
+	gitRun("config", "commit.gpgsign", "false")
+	dir := filepath.Join(root, "api", "ags", "v1")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	write := func(name, data string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(data), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("api.json", `{"actions":{},"objects":{"Req":{"members":[]}}}`)
+	write("api.patch.json", "[]")
+	write("e2e-coverage.yaml", "version: 1\ncoverage: []\n")
+	gitRun("add", ".")
+	gitRun("commit", "-m", "fixture")
+	head := gitRun("rev-parse", "HEAD")
+	args := func() []string {
+		return []string{"--repository", "example/repo", "--pr", "1", "--head", head, "--base", head, "--environment", "test"}
+	}
+	runReport := func() (Report, error) {
+		// Exercise worker preflight directly; archive_test drives the real launcher.
+		runnerCommit = head
+		var b bytes.Buffer
+		err := run(t.Context(), args(), &b)
+		var r Report
+		if e := json.Unmarshal(b.Bytes(), &r); e != nil {
+			t.Fatal(b.String(), e)
+		}
+		return r, err
+	}
+	r, err := runReport()
+	if err != nil || r.Status != "not_applicable" || r.Tree == "" || r.Plan.PatchDigest == "" {
+		t.Fatal(r, err)
+	}
+	write("extra.txt", "untracked")
+	if _, err := runReport(); err == nil {
+		t.Fatal("untracked source accepted")
+	}
+	gitRun("add", ".")
+	if _, err := runReport(); err == nil {
+		t.Fatal("staged source accepted")
+	}
+	gitRun("commit", "-m", "fixture2")
+	if _, err := runReport(); err == nil {
+		t.Fatal("stale head accepted")
+	}
+	head = gitRun("rev-parse", "HEAD")
+	write("api.patch.json", `[{"op":"add","path":"/objects/Req/type","value":"object"}]`)
+	write("e2e-coverage.yaml", "version: 1\ncoverage:\n  - entry: /objects/Req/type\n    scenario: fixture\n    assertions: [behavior]\n")
+	gitRun("add", ".")
+	gitRun("commit", "-m", "fixture3")
+	head = gitRun("rev-parse", "HEAD")
+	old := patchscenarios.Registry
+	t.Cleanup(func() { patchscenarios.Registry = old })
+	patchscenarios.Registry = patchtest.Registry{"fixture": {Assertions: []string{"behavior"}, Run: func(*patchtest.Session) error { t.Fatal("must not execute without credentials"); return nil }}}
+	t.Setenv("TENCENTCLOUD_SECRET_ID", "")
+	t.Setenv("TENCENTCLOUD_SECRET_KEY", "")
+	r, err = runReport()
+	if err == nil || r.Status != "fail" || !strings.Contains(r.Reason, "credentials") {
+		t.Fatal(r, err)
+	}
+	// Exercise archive -> build -> subprocess -> report using a local fixture,
+	// never a cloud endpoint. Dummy credentials go only to this fixture binary.
+	if err := os.MkdirAll(filepath.Join(root, "cmd", "agr"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	for name, data := range map[string]string{
+		"go.mod":          "module example.com/fixture\n\ngo 1.25.0\n",
+		"cmd/agr/main.go": "package main\nimport \"fmt\"\nfunc main(){fmt.Print(\"committed-fixture\")}\n",
+		".gitignore":      "cmd/agr/ignored.go\n",
+	} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(data), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	gitRun("add", ".")
+	gitRun("commit", "-m", "candidate-fixture")
+	head = gitRun("rev-parse", "HEAD")
+	// Ignored local source would break a worktree build; the archive excludes it.
+	if err := os.WriteFile(filepath.Join(root, "cmd", "agr", "ignored.go"), []byte("not valid Go"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	patchscenarios.Registry = patchtest.Registry{"fixture": {Assertions: []string{"behavior"}, Run: func(s *patchtest.Session) error {
+		s.NoResources()
+		b, err := s.CLI(s.Context)
+		if err != nil {
+			return err
+		}
+		return s.Assert("behavior", string(b) == "committed-fixture")
+	}}}
+	t.Setenv("TENCENTCLOUD_SECRET_ID", "fixture-only")
+	t.Setenv("TENCENTCLOUD_SECRET_KEY", "fixture-only")
+	t.Setenv("AGR_REGION", "fixture")
+	r, err = runReport()
+	if err != nil || r.Status != "pass" || r.Passed != 1 || r.Results[0].Cleanup != "pass" {
+		t.Fatal(r, err)
+	}
+}

--- a/cmd/internal/patch-e2e/main_test.go
+++ b/cmd/internal/patch-e2e/main_test.go
@@ -66,6 +66,20 @@ func TestStrictPreflight(t *testing.T) {
 	if err != nil || r.Status != "not_applicable" || r.Tree == "" || r.Plan.PatchDigest == "" {
 		t.Fatal(r, err)
 	}
+	alias := filepath.Join(t.TempDir(), "repo-alias")
+	if err := os.Symlink(root, alias); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(alias)
+	t.Setenv("PWD", alias)
+	if r, err := runReport(); err != nil || r.Status != "not_applicable" {
+		t.Fatalf("repository alias rejected: %+v %v", r, err)
+	}
+	t.Chdir(dir)
+	if r, err := runReport(); err == nil || r.Reason != "run from the repository root" {
+		t.Fatalf("repository subdirectory accepted: %+v %v", r, err)
+	}
+	t.Chdir(root)
 	write("extra.txt", "untracked")
 	if _, err := runReport(); err == nil {
 		t.Fatal("untracked source accepted")

--- a/cmd/internal/patch-e2e/main_test.go
+++ b/cmd/internal/patch-e2e/main_test.go
@@ -55,7 +55,7 @@ func TestStrictPreflight(t *testing.T) {
 		// Exercise worker preflight directly; archive_test drives the real launcher.
 		runnerCommit = head
 		var b bytes.Buffer
-		err := run(t.Context(), args(), &b)
+		err := run(t.Context(), args(), &b, &bytes.Buffer{})
 		var r Report
 		if e := json.Unmarshal(b.Bytes(), &r); e != nil {
 			t.Fatal(b.String(), e)

--- a/internal/patchcoverage/coverage.go
+++ b/internal/patchcoverage/coverage.go
@@ -1,0 +1,313 @@
+// Package patchcoverage derives coverage obligations from the complete effective
+// API, not from a hand-maintained list of patch operations.
+package patchcoverage
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"maps"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strings"
+
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/apimeta"
+	"go.yaml.in/yaml/v3"
+)
+
+type Entry struct {
+	ID            string `json:"id"`
+	Kind          string `json:"kind"`
+	Before        any    `json:"before"`
+	After         any    `json:"after"`
+	Documentation bool   `json:"documentation"`
+}
+
+type Binding struct {
+	Entry      string   `yaml:"entry" json:"entry"`
+	Scenario   string   `yaml:"scenario" json:"scenario"`
+	Assertions []string `yaml:"assertions" json:"assertions"`
+	Review     string   `yaml:"review" json:"review,omitempty"`
+}
+
+type Manifest struct {
+	Version  int       `yaml:"version"`
+	Coverage []Binding `yaml:"coverage"`
+}
+
+type Plan struct {
+	Entries     []Entry   `json:"entries"`
+	Bindings    []Binding `json:"bindings"`
+	PatchDigest string    `json:"patch_digest"`
+	Digest      string    `json:"plan_digest"`
+}
+
+// Registry maps scenario IDs to the assertion IDs implemented by that scenario.
+type Registry map[string][]string
+
+// Diff compares raw metadata so attributes absent from the generator's typed
+// projection cannot silently disappear. Member names replace array offsets.
+func Diff(base, effective []byte) ([]Entry, error) {
+	left, err := flatten(base)
+	if err != nil {
+		return nil, err
+	}
+	right, err := flatten(effective)
+	if err != nil {
+		return nil, err
+	}
+	keys := maps.Clone(left)
+	maps.Copy(keys, right)
+	var entries []Entry
+	for _, path := range slices.Sorted(maps.Keys(keys)) {
+		a, aok := left[path]
+		b, bok := right[path]
+		if aok == bok && reflect.DeepEqual(a, b) {
+			continue
+		}
+		doc, known := classify(path)
+		if !known {
+			return nil, fmt.Errorf("unclassified API change %s; extend the classifier and its tests", path)
+		}
+		kind := "change"
+		if !aok {
+			kind = "add"
+		} else if !bok {
+			kind = "remove"
+		}
+		entries = append(entries, Entry{ID: path, Kind: kind, Before: a, After: b, Documentation: doc})
+	}
+	return entries, nil
+}
+
+func escape(s string) string { return strings.ReplaceAll(strings.ReplaceAll(s, "~", "~0"), "/", "~1") }
+
+func flatten(data []byte) (map[string]any, error) {
+	var root map[string]any
+	d := json.NewDecoder(bytes.NewReader(data))
+	d.UseNumber()
+	if err := d.Decode(&root); err != nil {
+		return nil, err
+	}
+	out := map[string]any{}
+	var walk func(any, string) error
+	walk = func(value any, path string) error {
+		switch v := value.(type) {
+		case map[string]any:
+			// A presence marker catches empty Action/Object additions as well.
+			out[path+"/@exists"] = true
+			for _, key := range slices.Sorted(maps.Keys(v)) {
+				if key == "@exists" {
+					return fmt.Errorf("reserved metadata key at %s", path)
+				}
+				if err := walk(v[key], path+"/"+escape(key)); err != nil {
+					return err
+				}
+			}
+		case []any:
+			parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+			if len(parts) == 3 && parts[0] == "objects" && parts[2] == "members" {
+				out[path+"/@exists"] = true
+				seen := map[string]bool{}
+				for _, raw := range v {
+					member, ok := raw.(map[string]any)
+					if !ok {
+						return fmt.Errorf("invalid member at %s", path)
+					}
+					name, ok := member["name"].(string)
+					if !ok || name == "" || seen[name] {
+						return fmt.Errorf("missing or duplicate member name at %s", path)
+					}
+					seen[name] = true
+					if err := walk(member, path+"/"+escape(name)); err != nil {
+						return err
+					}
+				}
+			} else {
+				out[path] = v
+			}
+		default:
+			out[path] = v
+		}
+		return nil
+	}
+	if err := walk(root, ""); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func classify(path string) (documentation, known bool) {
+	p := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	if len(p) == 4 && p[0] == "objects" && p[2] == "members" && p[3] == "@exists" {
+		return false, true
+	}
+	if len(p) == 3 && p[0] == "actions" {
+		switch p[2] {
+		case "document", "name":
+			return true, true
+		case "@exists", "input", "output", "status":
+			return false, true
+		}
+	}
+	if len(p) == 3 && p[0] == "objects" {
+		switch p[2] {
+		case "document":
+			return true, true
+		case "@exists", "type", "usage":
+			return false, true
+		}
+	}
+	if len(p) == 5 && p[0] == "objects" && p[2] == "members" {
+		switch p[4] {
+		case "document", "example":
+			return true, true
+		case "@exists", "name", "type", "member", "required", "disabled",
+			"enum", "minimum", "maximum", "minLength", "maxLength", "pattern", "minItems", "maxItems":
+			return false, true
+		}
+	}
+	return false, false
+}
+
+// DigestFiles hashes sorted, length-prefixed path/content pairs. Whitespace
+// changes intentionally invalidate evidence too.
+func DigestFiles(files map[string][]byte) string {
+	h := sha256.New()
+	for _, path := range slices.Sorted(maps.Keys(files)) {
+		for _, value := range [][]byte{[]byte(path), files[path]} {
+			_ = binary.Write(h, binary.BigEndian, uint64(len(value)))
+			_, _ = h.Write(value)
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// Load always scans all API versions and rejects orphan/missing manifests.
+// validate=false is for printing obligations before a manifest is authored.
+func Load(root string, registry Registry, validate bool) (Plan, error) {
+	var plan Plan
+	patches := map[string][]byte{}
+	versions := map[string]bool{}
+	err := filepath.WalkDir(filepath.Join(root, "api", "ags"), func(path string, e fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if e.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("API symlinks are not supported: %s", path)
+		}
+		if !e.IsDir() && (e.Name() == "api.json" || e.Name() == "api.patch.json" || e.Name() == "e2e-coverage.yaml") {
+			versions[filepath.Dir(path)] = true
+		}
+		return nil
+	})
+	if err != nil {
+		return plan, err
+	}
+	if len(versions) == 0 {
+		return plan, fmt.Errorf("no API versions found")
+	}
+	for _, dir := range slices.Sorted(maps.Keys(versions)) {
+		base, err := os.ReadFile(filepath.Join(dir, "api.json"))
+		if err != nil {
+			return plan, err
+		}
+		patch, err := os.ReadFile(filepath.Join(dir, "api.patch.json"))
+		if err != nil {
+			return plan, err
+		}
+		rel, err := filepath.Rel(root, dir)
+		if err != nil {
+			return plan, err
+		}
+		rel = filepath.ToSlash(rel)
+		patches[rel+"/api.patch.json"] = patch
+		effective, err := apimeta.ApplyAPIPatch(base, patch)
+		if err != nil {
+			return plan, err
+		}
+		entries, err := Diff(base, effective)
+		if err != nil {
+			return plan, fmt.Errorf("%s: %w", rel, err)
+		}
+		for i := range entries {
+			entries[i].ID = rel + "#" + entries[i].ID
+		}
+		plan.Entries = append(plan.Entries, entries...)
+		if !validate {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, "e2e-coverage.yaml"))
+		if err != nil {
+			return plan, err
+		}
+		var manifest Manifest
+		d := yaml.NewDecoder(bytes.NewReader(data))
+		d.KnownFields(true)
+		if err := d.Decode(&manifest); err != nil {
+			return plan, err
+		}
+		if err := d.Decode(new(any)); err != io.EOF {
+			return plan, fmt.Errorf("%s: expected exactly one YAML document", rel)
+		}
+		if manifest.Version != 1 {
+			return plan, fmt.Errorf("%s: unsupported coverage version", rel)
+		}
+		for i := range manifest.Coverage {
+			manifest.Coverage[i].Entry = rel + "#" + manifest.Coverage[i].Entry
+		}
+		if err := Validate(entries, manifest.Coverage, registry); err != nil {
+			return plan, err
+		}
+		plan.Bindings = append(plan.Bindings, manifest.Coverage...)
+	}
+	plan.PatchDigest = DigestFiles(patches)
+	data, err := json.Marshal(plan)
+	if err != nil {
+		return plan, err
+	}
+	plan.Digest = DigestFiles(map[string][]byte{"plan-v1": data})
+	return plan, nil
+}
+
+func Validate(entries []Entry, bindings []Binding, registry Registry) error {
+	remaining := map[string]Entry{}
+	for _, e := range entries {
+		remaining[e.ID] = e
+	}
+	for _, b := range bindings {
+		e, ok := remaining[b.Entry]
+		if !ok {
+			return fmt.Errorf("unknown, stale or duplicate coverage entry: %s", b.Entry)
+		}
+		delete(remaining, b.Entry)
+		if e.Documentation && b.Scenario == "" {
+			if strings.TrimSpace(b.Review) == "" || len(b.Assertions) != 0 {
+				return fmt.Errorf("%s: documentation requires a review rationale", b.Entry)
+			}
+			continue
+		}
+		assertions, ok := registry[b.Scenario]
+		if !ok || len(b.Assertions) == 0 || b.Review != "" {
+			return fmt.Errorf("%s: registered scenario and assertions required", b.Entry)
+		}
+		seen := map[string]bool{}
+		for _, id := range b.Assertions {
+			if id == "" || seen[id] || !slices.Contains(assertions, id) {
+				return fmt.Errorf("%s: unknown or duplicate assertion %q", b.Entry, id)
+			}
+			seen[id] = true
+		}
+	}
+	if len(remaining) > 0 {
+		return fmt.Errorf("missing coverage: %s", strings.Join(slices.Sorted(maps.Keys(remaining)), ", "))
+	}
+	return nil
+}

--- a/internal/patchcoverage/coverage.go
+++ b/internal/patchcoverage/coverage.go
@@ -170,6 +170,7 @@ func classify(path string) (documentation, known bool) {
 		case "document", "example":
 			return true, true
 		case "@exists", "name", "type", "member", "required", "disabled",
+			"output_required", "value_allowed_null",
 			"enum", "minimum", "maximum", "minLength", "maxLength", "pattern", "minItems", "maxItems":
 			return false, true
 		}

--- a/internal/patchcoverage/coverage_test.go
+++ b/internal/patchcoverage/coverage_test.go
@@ -6,9 +6,110 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/apimeta"
 )
 
 const baseAPI = `{"actions":{"Get":{"input":"Req","output":"Resp","status":"online"}},"objects":{"Req":{"members":[]},"Resp":{"members":[{"name":"Id","type":"string","member":"string","required":true}]}}}`
+
+// Exercise all raw Action/Object metadata, even when the production patch is
+// empty. A typed projection or a handwritten attribute list can hide omissions.
+func TestCanonicalMetadataClassification(t *testing.T) {
+	paths, err := filepath.Glob("../../api/ags/*/api.json")
+	if err != nil || len(paths) == 0 {
+		t.Fatalf("find canonical APIs: %v (%v)", paths, err)
+	}
+	for _, path := range paths {
+		t.Run(filepath.Base(filepath.Dir(path)), func(t *testing.T) {
+			base, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var doc map[string]json.RawMessage
+			if err := json.Unmarshal(base, &doc); err != nil {
+				t.Fatal(err)
+			}
+			contract := map[string]json.RawMessage{}
+			for _, key := range []string{"actions", "objects"} {
+				if len(doc[key]) == 0 {
+					t.Fatalf("missing canonical %s", key)
+				}
+				contract[key] = doc[key]
+			}
+			data, err := json.Marshal(contract)
+			if err != nil {
+				t.Fatal(err)
+			}
+			empty := []byte(`{"actions":{},"objects":{}}`)
+			for _, pair := range [][2][]byte{{empty, data}, {data, empty}} {
+				entries, err := Diff(pair[0], pair[1])
+				if err != nil || len(entries) == 0 {
+					t.Fatalf("canonical metadata must be classified: %v", err)
+				}
+				if Validate(entries, nil, nil) == nil {
+					t.Fatal("canonical contract escaped coverage")
+				}
+			}
+			// A newly introduced, unclassified peer must trip the same gate.
+			var objects map[string]map[string]any
+			if err := json.Unmarshal(doc["objects"], &objects); err != nil {
+				t.Fatal(err)
+			}
+			for _, object := range objects {
+				members, _ := object["members"].([]any)
+				if len(members) == 0 {
+					continue
+				}
+				members[0].(map[string]any)["unclassified_peer"] = true
+				changed, err := json.Marshal(map[string]any{"objects": objects})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := Diff([]byte(`{"objects":{}}`), changed); err == nil || !strings.Contains(err.Error(), "/unclassified_peer") {
+					t.Fatalf("new canonical attribute escaped classification: %v", err)
+				}
+				return
+			}
+			t.Fatal("canonical API has no members")
+		})
+	}
+}
+
+func TestCanonicalResponseConstraints(t *testing.T) {
+	base, err := os.ReadFile("../../api/ags/v20250920/api.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{"output_required", "value_allowed_null"} {
+		t.Run(field, func(t *testing.T) {
+			patch, err := json.Marshal([]map[string]any{
+				{"op": "test", "path": "/objects/APIKeyInfo/members/0/" + field, "value": false},
+				{"op": "replace", "path": "/objects/APIKeyInfo/members/0/" + field, "value": true},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			effective, err := apimeta.ApplyAPIPatch(base, patch)
+			if err != nil {
+				t.Fatal(err)
+			}
+			entries, err := Diff(base, effective)
+			if err != nil || len(entries) != 1 {
+				t.Fatalf("response constraint delta: %+v %v", entries, err)
+			}
+			e := entries[0]
+			if e.ID != "/objects/APIKeyInfo/members/Name/"+field || e.Kind != "change" || e.Documentation || e.Before != false || e.After != true {
+				t.Fatalf("incorrect response constraint: %+v", e)
+			}
+			if Validate(entries, []Binding{{Entry: e.ID, Review: "documentation only"}}, nil) == nil {
+				t.Fatal("response constraint accepted without a live scenario")
+			}
+			if err := Validate(entries, []Binding{{Entry: e.ID, Scenario: "response", Assertions: []string{"constraint"}}}, Registry{"response": {"constraint"}}); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
 
 func TestDiffAndCoverageNewPeerFails(t *testing.T) {
 	effective := strings.Replace(baseAPI, `"members":[]`, `"members":[{"name":"Name","type":"string","member":"string","required":false}]`, 1)

--- a/internal/patchcoverage/coverage_test.go
+++ b/internal/patchcoverage/coverage_test.go
@@ -1,0 +1,205 @@
+package patchcoverage
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const baseAPI = `{"actions":{"Get":{"input":"Req","output":"Resp","status":"online"}},"objects":{"Req":{"members":[]},"Resp":{"members":[{"name":"Id","type":"string","member":"string","required":true}]}}}`
+
+func TestDiffAndCoverageNewPeerFails(t *testing.T) {
+	effective := strings.Replace(baseAPI, `"members":[]`, `"members":[{"name":"Name","type":"string","member":"string","required":false}]`, 1)
+	entries, err := Diff([]byte(baseAPI), []byte(effective))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 5 {
+		t.Fatalf("want presence/name/type/member/required, got %+v", entries)
+	}
+	registry := Registry{"get": {"readback"}}
+	var bindings []Binding
+	for _, e := range entries {
+		bindings = append(bindings, Binding{Entry: e.ID, Scenario: "get", Assertions: []string{"readback"}})
+	}
+	if err := Validate(entries, bindings, registry); err != nil {
+		t.Fatal(err)
+	}
+	peer := strings.Replace(effective, `"required":false}`, `"required":false},{"name":"Other","type":"string","member":"string"}`, 1)
+	more, err := Diff([]byte(baseAPI), []byte(peer))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Validate(more, bindings, registry); err == nil || !strings.Contains(err.Error(), "missing coverage") {
+		t.Fatalf("new peer must fail: %v", err)
+	}
+	for _, mutate := range []func([]Binding) []Binding{
+		func(b []Binding) []Binding { return b[1:] },
+		func(b []Binding) []Binding { b[0].Scenario = "missing"; return b },
+		func(b []Binding) []Binding { b[0].Assertions = []string{"missing"}; return b },
+		func(b []Binding) []Binding { return append(b, b[0]) },
+		func(b []Binding) []Binding { b[0].Entry = "stale"; return b },
+	} {
+		if Validate(entries, mutate(append([]Binding(nil), bindings...)), registry) == nil {
+			t.Fatal("invalid mapping passed")
+		}
+	}
+}
+
+func TestDiffRawConstraintsAndRemovals(t *testing.T) {
+	for _, field := range []string{"required", "type", "enum", "minimum", "maximum", "minLength", "maxLength", "pattern", "minItems", "maxItems", "disabled"} {
+		t.Run(field, func(t *testing.T) {
+			var doc map[string]any
+			if err := json.Unmarshal([]byte(baseAPI), &doc); err != nil {
+				t.Fatal(err)
+			}
+			member := doc["objects"].(map[string]any)["Resp"].(map[string]any)["members"].([]any)[0].(map[string]any)
+			member[field] = "changed"
+			data, _ := json.Marshal(doc)
+			delta, err := Diff([]byte(baseAPI), data)
+			if err != nil || len(delta) != 1 || delta[0].Documentation {
+				t.Fatalf("lost raw %s: %+v %v", field, delta, err)
+			}
+			reverse, err := Diff(data, []byte(baseAPI))
+			if err != nil || len(reverse) != 1 {
+				t.Fatalf("lost removal %s", field)
+			}
+		})
+	}
+	unknown := strings.Replace(baseAPI, `"status":"online"`, `"status":"online","surprise":true`, 1)
+	if _, err := Diff([]byte(baseAPI), []byte(unknown)); err == nil {
+		t.Fatal("unknown metadata passed")
+	}
+	removed := strings.Replace(baseAPI, `"Get":{"input":"Req","output":"Resp","status":"online"}`, ``, 1)
+	entries, err := Diff([]byte(baseAPI), []byte(removed))
+	if err != nil || len(entries) != 4 {
+		t.Fatalf("action removal: %+v %v", entries, err)
+	}
+}
+
+func TestMemberOrderAndDocumentation(t *testing.T) {
+	a := `{"objects":{"R":{"members":[{"name":"A"},{"name":"B"}]}}}`
+	b := `{"objects":{"R":{"members":[{"name":"B"},{"name":"A"}]}}}`
+	delta, err := Diff([]byte(a), []byte(b))
+	if err != nil || len(delta) != 0 {
+		t.Fatalf("order is not a contract change: %v %v", delta, err)
+	}
+	b = strings.Replace(a, `"name":"A"`, `"name":"A","document":"new constraint in prose"`, 1)
+	delta, err = Diff([]byte(a), []byte(b))
+	if err != nil || len(delta) != 1 || !delta[0].Documentation {
+		t.Fatal(delta, err)
+	}
+	if Validate(delta, []Binding{{Entry: delta[0].ID}}, nil) == nil {
+		t.Fatal("unreviewed prose passed")
+	}
+	if err := Validate(delta, []Binding{{Entry: delta[0].ID, Review: "reviewer must determine whether this needs live assertions"}}, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoadAllVersionsAndDigest(t *testing.T) {
+	root := t.TempDir()
+	write := func(version, file, data string) {
+		t.Helper()
+		dir := filepath.Join(root, "api", "ags", version)
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, file), []byte(data), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, v := range []string{"v1", "v2"} {
+		write(v, "api.json", baseAPI)
+		write(v, "api.patch.json", "[]")
+		write(v, "e2e-coverage.yaml", "version: 1\ncoverage: []\n")
+	}
+	plan, err := Load(root, nil, true)
+	if err != nil || len(plan.Entries) != 0 {
+		t.Fatal(plan, err)
+	}
+	write("v2", "api.patch.json", "[ ]")
+	other, err := Load(root, nil, true)
+	if err != nil || other.PatchDigest == plan.PatchDigest {
+		t.Fatal("patch digest did not change", err)
+	}
+	write("v2", "api.patch.json", `[{"op":"add","path":"/objects/Req/members/-","value":{"name":"X","type":"string","member":"string"}}]`)
+	if _, err := Load(root, nil, true); err == nil {
+		t.Fatal("second version escaped coverage")
+	}
+	if _, err := Load(root, nil, false); err != nil {
+		t.Fatal(err)
+	}
+	write("v2", "api.patch.json", `[{"op":"copy","from":"/objects/Req","path":"/objects/Other"}]`)
+	if _, err := Load(root, nil, false); err == nil {
+		t.Fatal("unsupported op silently accepted")
+	}
+	if DigestFiles(map[string][]byte{"a": []byte("bc")}) == DigestFiles(map[string][]byte{"ab": []byte("c")}) {
+		t.Fatal("ambiguous digest")
+	}
+}
+
+func TestManifestStrictness(t *testing.T) {
+	for _, manifest := range []string{
+		"version: 1\ncoverage: []\nunknown: true\n",
+		"version: 1\nversion: 1\ncoverage: []\n",
+		"version: 1\ncoverage: []\n---\nversion: 1\n",
+		"version: 2\ncoverage: []\n",
+	} {
+		root := t.TempDir()
+		dir := filepath.Join(root, "api", "ags", "v1")
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			t.Fatal(err)
+		}
+		for name, data := range map[string]string{"api.json": baseAPI, "api.patch.json": "[]", "e2e-coverage.yaml": manifest} {
+			if err := os.WriteFile(filepath.Join(dir, name), []byte(data), 0600); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if _, err := Load(root, nil, true); err == nil {
+			t.Fatalf("invalid manifest passed: %s", manifest)
+		}
+	}
+}
+
+func TestEmptyMembersChanges(t *testing.T) {
+	for _, path := range []string{"", "/actions/Get", "/objects/Req/members/0"} {
+		t.Run(path, func(t *testing.T) {
+			base := `{"actions":{"Get":{}},"objects":{"Req":{"members":[{"name":"A"}]}}}`
+			var doc map[string]any
+			if err := json.Unmarshal([]byte(base), &doc); err != nil {
+				t.Fatal(err)
+			}
+			target := doc
+			switch path {
+			case "/actions/Get":
+				target = doc["actions"].(map[string]any)["Get"].(map[string]any)
+			case "/objects/Req/members/0":
+				target = doc["objects"].(map[string]any)["Req"].(map[string]any)["members"].([]any)[0].(map[string]any)
+			}
+			target["members"] = []any{}
+			effective, err := json.Marshal(doc)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, pair := range [][2][]byte{{[]byte(base), effective}, {effective, []byte(base)}} {
+				if _, err := Diff(pair[0], pair[1]); err == nil {
+					t.Fatal("unknown empty members change accepted")
+				}
+			}
+		})
+	}
+	base := []byte(`{"objects":{"Req":{}}}`)
+	effective := []byte(`{"objects":{"Req":{"members":[]}}}`)
+	for _, pair := range [][2][]byte{{base, effective}, {effective, base}} {
+		delta, err := Diff(pair[0], pair[1])
+		if err != nil || len(delta) != 1 || delta[0].ID != "/objects/Req/members/@exists" {
+			t.Fatalf("lost members presence: %+v %v", delta, err)
+		}
+		if Validate(delta, nil, nil) == nil {
+			t.Fatal("members presence escaped coverage")
+		}
+	}
+}

--- a/internal/patchscenarios/registry.go
+++ b/internal/patchscenarios/registry.go
@@ -1,0 +1,9 @@
+// Package patchscenarios registers reviewed, real CLI test scenarios. Add a
+// scenario together with its first preview-only patch, never a success stub.
+package patchscenarios
+
+import "github.com/TencentCloudAgentRuntime/ags-cli/internal/patchtest"
+
+// Registry is empty because the canonical branch has no API patches.
+// Scenarios remain ordinary Go source, subject to independent assertion review.
+var Registry = patchtest.Registry{}

--- a/internal/patchtest/runner.go
+++ b/internal/patchtest/runner.go
@@ -1,0 +1,156 @@
+// Package patchtest provides fail-closed execution for registered live CLI
+// scenarios. Assertion records are execution evidence, not proof of test quality.
+package patchtest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"os/exec"
+	"slices"
+	"time"
+
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/patchcoverage"
+)
+
+type Scenario struct {
+	Assertions []string
+	Run        func(*Session) error
+}
+type Registry map[string]Scenario
+
+func (r Registry) Coverage() patchcoverage.Registry {
+	out := patchcoverage.Registry{}
+	for id, s := range r {
+		if s.Run != nil {
+			out[id] = s.Assertions
+		}
+	}
+	return out
+}
+
+type Result struct {
+	Scenario   string   `json:"scenario"`
+	Status     string   `json:"status"`
+	Assertions []string `json:"assertions"`
+	Calls      int      `json:"cli_calls"`
+	Cleanup    string   `json:"cleanup"`
+}
+
+// Session is single-threaded. Register cleanup immediately after obtaining any
+// resource ID, including IDs returned with partial failures.
+type Session struct {
+	Context     context.Context
+	binary      string
+	env         []string
+	assertions  map[string]bool
+	allowed     []string
+	failed      bool
+	skipped     bool
+	calls       int
+	cleanups    []func(context.Context) error
+	noResources bool
+}
+
+// CLI invokes the candidate binary, never the SDK or a configurable executable.
+// Output stays in memory for assertions and is not copied into public reports.
+func (s *Session) CLI(ctx context.Context, args ...string) ([]byte, error) {
+	s.calls++
+	cmd := exec.CommandContext(ctx, s.binary, args...)
+	cmd.Env = s.env
+	return cmd.Output()
+}
+
+// Assert must be called after checking the actual request/readback/behavior.
+func (s *Session) Assert(id string, condition bool) error {
+	if !condition || !slices.Contains(s.allowed, id) {
+		s.failed = true
+		return fmt.Errorf("assertion failed")
+	}
+	s.assertions[id] = true
+	return nil
+}
+
+func (s *Session) Skip()                                  { s.skipped = true }
+func (s *Session) Cleanup(fn func(context.Context) error) { s.cleanups = append(s.cleanups, fn) }
+
+// NoResources is an explicit, reviewer-audited declaration for read-only cases.
+// It does not waive any registered cleanup callbacks.
+func (s *Session) NoResources() { s.noResources = true }
+
+func Run(ctx context.Context, plan patchcoverage.Plan, registry Registry, binary string, env []string) ([]Result, error) {
+	selected := map[string]map[string]bool{}
+	for _, b := range plan.Bindings {
+		if b.Scenario == "" {
+			continue
+		}
+		if selected[b.Scenario] == nil {
+			selected[b.Scenario] = map[string]bool{}
+		}
+		for _, a := range b.Assertions {
+			selected[b.Scenario][a] = true
+		}
+	}
+	var results []Result
+	var failures []error
+	for _, id := range slices.Sorted(maps.Keys(selected)) {
+		spec, ok := registry[id]
+		if !ok || spec.Run == nil {
+			return results, fmt.Errorf("unregistered scenario %s", id)
+		}
+		s := &Session{Context: ctx, binary: binary, env: env, allowed: spec.Assertions, assertions: map[string]bool{}}
+		result := Result{Scenario: id, Status: "pass", Cleanup: "pass"}
+		err := invoke(func() error { return spec.Run(s) })
+		if err != nil || s.failed || ctx.Err() != nil {
+			result.Status = "fail"
+		}
+		if s.calls == 0 {
+			result.Status = "fail"
+		}
+		for a := range selected[id] {
+			if !s.assertions[a] {
+				result.Status = "fail"
+			}
+		}
+		if len(s.cleanups) == 0 && !s.noResources {
+			result.Cleanup = "unconfirmed"
+			result.Status = "fail"
+		}
+		for i := len(s.cleanups) - 1; i >= 0; i-- {
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			err := invoke(func() error { return s.cleanups[i](cleanupCtx) })
+			cleanupTimedOut := cleanupCtx.Err() != nil
+			cancel()
+			if err != nil || cleanupTimedOut {
+				result.Cleanup = "fail"
+				result.Status = "fail"
+			}
+		}
+		result.Assertions = slices.Sorted(maps.Keys(s.assertions))
+		result.Calls = s.calls
+		// Preserve skip accounting even when the skipped body did not execute
+		// its assertions. Cleanup status remains separately visible.
+		if s.skipped {
+			result.Status = "skip"
+		}
+		results = append(results, result)
+		if result.Status != "pass" {
+			failures = append(failures, fmt.Errorf("scenario %s did not pass", id))
+		}
+	}
+	return results, errors.Join(failures...)
+}
+
+func invoke(fn func() error) (err error) {
+	defer func() {
+		if recover() != nil {
+			err = fmt.Errorf("scenario or cleanup panicked")
+		}
+	}()
+	return fn()
+}
+
+// EncodeReport deliberately excludes raw scenario errors, argv and responses.
+func EncodeReport(value any) ([]byte, error) { return json.MarshalIndent(value, "", "  ") }

--- a/internal/patchtest/runner_test.go
+++ b/internal/patchtest/runner_test.go
@@ -1,0 +1,100 @@
+package patchtest
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/TencentCloudAgentRuntime/ags-cli/internal/patchcoverage"
+)
+
+// The local subprocess tests the runner protocol only, never live correctness.
+func TestChild(t *testing.T) {
+	if os.Getenv("PATCH_RUNNER_CHILD") == "1" {
+		os.Exit(0)
+	}
+}
+
+func TestStrictRunner(t *testing.T) {
+	binary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := patchcoverage.Plan{Bindings: []patchcoverage.Binding{{Scenario: "case", Assertions: []string{"readback"}}}}
+	for _, mode := range []string{"pass", "skip", "missing-assertion", "failed-assertion", "unknown-assertion", "failure", "panic", "cleanup-failure", "cleanup-panic", "unconfirmed", "no-cli"} {
+		t.Run(mode, func(t *testing.T) {
+			cleaned := false
+			registry := Registry{"case": {Assertions: []string{"readback"}, Run: func(s *Session) error {
+				if mode != "unconfirmed" {
+					s.Cleanup(func(context.Context) error {
+						cleaned = true
+						if mode == "cleanup-panic" {
+							panic("secret")
+						}
+						if mode == "cleanup-failure" {
+							return errors.New("secret")
+						}
+						return nil
+					})
+				}
+				if mode == "panic" {
+					panic("secret")
+				}
+				if mode != "no-cli" {
+					if _, err := s.CLI(s.Context, "-test.run=TestChild"); err != nil {
+						return err
+					}
+				}
+				if mode == "skip" {
+					s.Skip()
+				}
+				if mode == "failed-assertion" {
+					_ = s.Assert("readback", false)
+				}
+				if mode == "unknown-assertion" {
+					_ = s.Assert("unknown", true)
+				}
+				if mode != "missing-assertion" {
+					_ = s.Assert("readback", true)
+				}
+				if mode == "failure" {
+					return errors.New("secret")
+				}
+				return nil
+			}}}
+			results, err := Run(t.Context(), plan, registry, binary, append(os.Environ(), "PATCH_RUNNER_CHILD=1"))
+			if (err == nil) != (mode == "pass") {
+				t.Fatalf("%s: %+v %v", mode, results, err)
+			}
+			if mode != "unconfirmed" && !cleaned {
+				t.Fatal("cleanup not attempted")
+			}
+		})
+	}
+	if _, err := Run(t.Context(), plan, Registry{}, binary, nil); err == nil {
+		t.Fatal("unknown selected scenario passed")
+	}
+}
+
+func TestCleanupAfterCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	var order []int
+	registry := Registry{"case": {Assertions: []string{"a"}, Run: func(s *Session) error {
+		s.Cleanup(func(ctx context.Context) error {
+			if ctx.Err() != nil {
+				t.Error("cleanup inherited cancelled context")
+			}
+			order = append(order, 1)
+			return nil
+		})
+		s.Cleanup(func(context.Context) error { order = append(order, 2); return errors.New("cleanup failure") })
+		cancel()
+		return nil
+	}}}
+	plan := patchcoverage.Plan{Bindings: []patchcoverage.Binding{{Scenario: "case", Assertions: []string{"a"}}}}
+	results, err := Run(ctx, plan, registry, "unused", nil)
+	if err == nil || len(order) != 2 || order[0] != 2 || order[1] != 1 || results[0].Cleanup != "fail" {
+		t.Fatal(order, results, err)
+	}
+}


### PR DESCRIPTION
## Summary

Related to #113; this implements contract-to-test coverage and the manual evidence workflow, not the complete governance issue.

- Derive additions, changes and removals from the complete effective API across all versions, requiring registered scenario/assertion mappings or explicit documentation-review rationales.
- Add credential-free `Patch Contract Coverage` to `CI Gate`, plus `apipatch delta`, `apipatch coverage` and Make targets.
- Add a strict local runner that builds test scenarios and the candidate CLI from the recorded commit, rejects mismatched workers and dirty checkouts, and reports assertions, source identity, digests and cleanup.
- Disable automatic VCS stamping for both archive builds; preserve compiler diagnostics on local stderr, separate from the public JSON report.
- Document two native approvals for every PR targeting `preview`, author-nominated API review, independent reproduction and safe disposable test environments.

## Verification

- Go 1.25.0: `go test -race ./cmd/internal/patch-e2e ./internal/patchcoverage ./internal/patchtest -count=1` passed.
- Go 1.26.0: `go test -race ./cmd/internal/patch-e2e -count=1` passed. Added Go 1.26.x archive tests to the existing Linux/macOS CI test jobs, without cloud credentials.
- Compiler-diagnostic regression fails against the previous implementation and passes with the fix. The reported original VCS-status failure was not reproduced locally on Go 1.26.0; no fail-before/pass-after claim is made for that specific environment-dependent error.
- Canonical raw API metadata completeness and response-constraint regressions passed; the latter reproduced the previous classification omissions before their fix.
- Targeted lint, `actionlint .github/workflows/ci.yml`, and `git diff --check` passed for the latest changes.
- Earlier PR verification also passed repository Go tests with live cloud suites excluded, `apipatch coverage`, and `cobragen check`.
- Local subprocess tests cover committed scenario identity, ignored source, stale workers, missing credentials, skipped/failed/missing assertions, cancellation, cleanup and build failures.

## Scope and remaining prerequisites

- Targets `main`; the API patch and production scenario registry remain empty. No API/SDK/generated CLI changes or real cloud E2E verification are included.
- Static coverage validates bookkeeping, not assertion quality or backend correctness. A trusted reviewer must audit assertions and independently reproduce real patch tests.
- No real-E2E CI workflow is added in this phase. Future automation requires separate evaluation.
- Every candidate containing a non-empty patch must attach or link a real local E2E report before merging: command without credentials, current head/base, source tree, patch/plan digests, environment alias, timestamps, scenarios/assertions, pass/fail/skip counts and cleanup results. Static CI does not verify report attachment or runtime correctness.
- Reports are local evidence, not cryptographically trusted GitHub checks. Independent reproduction and source/disclosure verification remain required. Empty-patch tooling PRs, including this PR, do not require a live patch report.
- Every PR targeting `preview` requires two different approving maintainers with repository write access or higher; no fixed teams or API-owner/CLI-maintainer team quotas are required. The existing `protect-preview` ruleset has been updated separately to require two approvals and read back to confirm; canary approval-flow testing remains outstanding.
- For non-empty patches, the author nominates an API reviewer other than themselves. The lead maintainer verifies that reviewer's identity, expertise and explicit acceptance. An API reviewer without write access provides supporting evidence and does not count toward the two native approvals.
- Existing patch operation restrictions, including rejection of `move`/`copy`, are unchanged.
